### PR TITLE
remove username and password from external.toml

### DIFF
--- a/cmd/proxy/config/external.toml
+++ b/cmd/proxy/config/external.toml
@@ -2,5 +2,3 @@
 [ElasticSearchConnector]
     Enabled    = true
     URL        = "https://elastic-aws.elrond.com"
-    Username   = "basic_auth_username"
-    Password   = "basic_auth_password"

--- a/process/database/elasticSearchConnector_test.go
+++ b/process/database/elasticSearchConnector_test.go
@@ -11,8 +11,8 @@ func TestDatabaseReader(t *testing.T) {
 	t.Skip("this test queries Elastic Search")
 
 	url := "https://elastic-aws.elrond.com"
-	user := "basic_auth_username"
-	password := "basic_auth_password"
+	user := ""
+	password := ""
 	reader, err := NewElasticSearchConnector(url, user, password)
 	require.Nil(t, err)
 
@@ -26,8 +26,8 @@ func TestDatabaseReader_GetLatestBlockHeight(t *testing.T) {
 	t.Skip("this test queries Elastic Search")
 
 	url := "https://elastic-aws.elrond.com"
-	user := "basic_auth_username"
-	password := "basic_auth_password"
+	user := ""
+	password := ""
 	reader, err := NewElasticSearchConnector(url, user, password)
 	require.Nil(t, err)
 


### PR DESCRIPTION
Removed username and password from external.toml  because are no needed. (for read operations are no needed)