### PR TITLE
changed the data field as byte array

### DIFF
--- a/data/transaction.go
+++ b/data/transaction.go
@@ -17,7 +17,7 @@ type Transaction struct {
 	Sender    string `form:"sender" json:"sender"`
 	GasPrice  uint64 `form:"gasPrice" json:"gasPrice,omitempty"`
 	GasLimit  uint64 `form:"gasLimit" json:"gasLimit,omitempty"`
-	Data      string `form:"data" json:"data,omitempty"`
+	Data      []byte `form:"data" json:"data,omitempty"`
 	Signature string `form:"signature" json:"signature,omitempty"`
 	ChainID   string `form:"chainID" json:"chainID"`
 	Version   uint32 `form:"version" json:"version"`
@@ -85,7 +85,7 @@ func (tw *transactionWrapper) GetGasPrice() uint64 {
 
 // GetData will return the data of the tx
 func (tw *transactionWrapper) GetData() []byte {
-	return []byte(tw.transaction.Data)
+	return tw.transaction.Data
 }
 
 // TransactionResponseData represents the format of the data field of a transaction response

--- a/data/transaction_test.go
+++ b/data/transaction_test.go
@@ -49,7 +49,7 @@ func TestTransactionWrapper_Getters(t *testing.T) {
 		Sender:    "",
 		GasPrice:  gasPrice,
 		GasLimit:  gasLimit,
-		Data:      data,
+		Data:      []byte(data),
 		Signature: "",
 	}
 	tw, _ := NewTransactionWrapper(&tx, &mock.PubKeyConverterMock{})

--- a/process/faucetProcessor.go
+++ b/process/faucetProcessor.go
@@ -134,7 +134,7 @@ func (fp *FaucetProcessor) GenerateTxForSendUserFunds(
 		Receiver:  receiver,
 		Sender:    senderPk,
 		GasPrice:  fp.minGasPrice,
-		Data:      "",
+		Data:      []byte(""),
 		Signature: "",
 		ChainID:   chainID,
 		Version:   version,

--- a/process/transactionProcessor.go
+++ b/process/transactionProcessor.go
@@ -35,7 +35,7 @@ type erdTransaction struct {
 	SndAddr   string `json:"sender"`
 	GasPrice  uint64 `json:"gasPrice,omitempty"`
 	GasLimit  uint64 `json:"gasLimit,omitempty"`
-	Data      string `json:"data,omitempty"`
+	Data      []byte `json:"data,omitempty"`
 	Signature string `json:"signature,omitempty"`
 	ChainID   string `json:"chainID"`
 	Version   uint32 `json:"version"`


### PR DESCRIPTION
Changed the `data` field of transactions to byte array instead of string in order to avoid issues of golang's json marshaler.