### PR TITLE
Disable external queries (by default)

### DIFF
--- a/cmd/proxy/config/external.toml
+++ b/cmd/proxy/config/external.toml
@@ -1,4 +1,4 @@
 # ElasticSearchConnector defines settings related to ElasticSearch such as login information or URL
 [ElasticSearchConnector]
-    Enabled    = true
-    URL        = "https://elastic-aws.elrond.com"
+    Enabled    = false
+    URL        = ""


### PR DESCRIPTION
Disable queries against Elastic Search (by default). Only the default Proxy instance will have this enabled.