### PR TITLE
Exchanges integration: add hyperblock coordinates

### DIFF
--- a/data/transaction.go
+++ b/data/transaction.go
@@ -37,8 +37,8 @@ type FullTransaction struct {
 	Data                              []byte                 `json:"data,omitempty"`
 	Code                              string                 `json:"code,omitempty"`
 	Signature                         string                 `json:"signature,omitempty"`
-	SourceShard                       uint32                 `json:"sourceShard"`
-	DestinationShard                  uint32                 `json:"destinationShard"`
+	SourceShard                       uint32                 `json:"sourceShard,omitempty"`
+	DestinationShard                  uint32                 `json:"destinationShard,omitempty"`
 	BlockNonce                        uint64                 `json:"blockNonce,omitempty"`
 	BlockHash                         string                 `json:"blockHash,omitempty"`
 	NotarizedAtSourceInMetaNonce      uint64                 `json:"notarizedAtSourceInMetaNonce,omitempty"`
@@ -48,8 +48,8 @@ type FullTransaction struct {
 	MiniBlockHash                     string                 `json:"miniblockHash,omitempty"`
 	Status                            core.TransactionStatus `json:"status,omitempty"`
 
-	HyperblockNonce uint64 `json:"hyperblockNonce"`
-	HyperblockHash  string `json:"hyperblockHash"`
+	HyperblockNonce uint64 `json:"hyperblockNonce,omitempty"`
+	HyperblockHash  string `json:"hyperblockHash,omitempty"`
 }
 
 // GetTransactionResponseData follows the format of the data field of get transaction response

--- a/data/transaction.go
+++ b/data/transaction.go
@@ -47,9 +47,8 @@ type FullTransaction struct {
 	NotarizedAtDestinationInMetaHash  string                 `json:"notarizedAtDestinationInMetaHash,omitempty"`
 	MiniBlockHash                     string                 `json:"miniblockHash,omitempty"`
 	Status                            core.TransactionStatus `json:"status,omitempty"`
-
-	HyperblockNonce uint64 `json:"hyperblockNonce,omitempty"`
-	HyperblockHash  string `json:"hyperblockHash,omitempty"`
+	HyperblockNonce                   uint64                 `json:"hyperblockNonce,omitempty"`
+	HyperblockHash                    string                 `json:"hyperblockHash,omitempty"`
 }
 
 // GetTransactionResponseData follows the format of the data field of get transaction response

--- a/data/transaction.go
+++ b/data/transaction.go
@@ -24,25 +24,32 @@ type Transaction struct {
 
 // FullTransaction is a transaction featuring all data saved in the full history
 type FullTransaction struct {
-	Type             string                 `json:"type"`
-	Hash             string                 `json:"hash,omitempty"`
-	Nonce            uint64                 `json:"nonce,omitempty"`
-	Round            uint64                 `json:"round,omitempty"`
-	Epoch            uint32                 `json:"epoch,omitempty"`
-	Value            string                 `json:"value,omitempty"`
-	Receiver         string                 `json:"receiver,omitempty"`
-	Sender           string                 `json:"sender,omitempty"`
-	GasPrice         uint64                 `json:"gasPrice,omitempty"`
-	GasLimit         uint64                 `json:"gasLimit,omitempty"`
-	Data             []byte                 `json:"data,omitempty"`
-	Code             string                 `json:"code,omitempty"`
-	Signature        string                 `json:"signature,omitempty"`
-	SourceShard      uint32                 `json:"sourceShard,omitempty"`
-	DestinationShard uint32                 `json:"destinationShard,omitempty"`
-	BlockNonce       uint64                 `json:"blockNonce,omitempty"`
-	MiniBlockHash    string                 `json:"miniblockHash,omitempty"`
-	BlockHash        string                 `json:"blockHash,omitempty"`
-	Status           core.TransactionStatus `json:"status,omitempty"`
+	Type                              string                 `json:"type"`
+	Hash                              string                 `json:"hash,omitempty"`
+	Nonce                             uint64                 `json:"nonce,omitempty"`
+	Round                             uint64                 `json:"round,omitempty"`
+	Epoch                             uint32                 `json:"epoch,omitempty"`
+	Value                             string                 `json:"value,omitempty"`
+	Receiver                          string                 `json:"receiver,omitempty"`
+	Sender                            string                 `json:"sender,omitempty"`
+	GasPrice                          uint64                 `json:"gasPrice,omitempty"`
+	GasLimit                          uint64                 `json:"gasLimit,omitempty"`
+	Data                              []byte                 `json:"data,omitempty"`
+	Code                              string                 `json:"code,omitempty"`
+	Signature                         string                 `json:"signature,omitempty"`
+	SourceShard                       uint32                 `json:"sourceShard"`
+	DestinationShard                  uint32                 `json:"destinationShard"`
+	BlockNonce                        uint64                 `json:"blockNonce,omitempty"`
+	BlockHash                         string                 `json:"blockHash,omitempty"`
+	NotarizedAtSourceInMetaNonce      uint64                 `json:"notarizedAtSourceInMetaNonce,omitempty"`
+	NotarizedAtSourceInMetaHash       string                 `json:"NotarizedAtSourceInMetaHash,omitempty"`
+	NotarizedAtDestinationInMetaNonce uint64                 `json:"notarizedAtDestinationInMetaNonce,omitempty"`
+	NotarizedAtDestinationInMetaHash  string                 `json:"notarizedAtDestinationInMetaHash,omitempty"`
+	MiniBlockHash                     string                 `json:"miniblockHash,omitempty"`
+	Status                            core.TransactionStatus `json:"status,omitempty"`
+
+	HyperblockNonce uint64 `json:"hyperblockNonce"`
+	HyperblockHash  string `json:"hyperblockHash"`
 }
 
 // GetTransactionResponseData follows the format of the data field of get transaction response

--- a/process/transactionProcessor.go
+++ b/process/transactionProcessor.go
@@ -216,7 +216,14 @@ func (tp *TransactionProcessor) TransactionCostRequest(tx *data.Transaction) (st
 
 // GetTransaction should return a transaction from observer
 func (tp *TransactionProcessor) GetTransaction(txHash string) (*data.FullTransaction, error) {
-	return tp.getTxFromObservers(txHash)
+	tx, err := tp.getTxFromObservers(txHash)
+	if err != nil {
+		return nil, err
+	}
+
+	tx.HyperblockNonce = tx.NotarizedAtDestinationInMetaNonce
+	tx.HyperblockHash = tx.NotarizedAtDestinationInMetaHash
+	return tx, nil
 }
 
 //GetTransactionByHashAndSenderAddress returns a transaction


### PR DESCRIPTION
Include hyperblock coordinates (nonce, hash) in the response of `transaction/abracadabra`.

How to test:

 - send a transaction
 - GET `transaction/abracadabra` repeatedly until the hyperblock fields are set
 - GET `hyperblock/by-nonce/42` and see the transaction included
 - do this for several different epochs