### PR TITLE
EN-7522: compute shard ID for a given address

### DIFF
--- a/api/address/interface.go
+++ b/api/address/interface.go
@@ -8,5 +8,6 @@ import (
 type FacadeHandler interface {
 	GetAccount(address string) (*data.Account, error)
 	GetTransactions(address string) ([]data.DatabaseTransaction, error)
+	GetShardIDForAddress(address string) (uint32, error)
 	GetValueForKey(address string, key string) (string, error)
 }

--- a/api/address/routes_test.go
+++ b/api/address/routes_test.go
@@ -8,6 +8,7 @@ import (
 	"math/big"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/ElrondNetwork/elrond-proxy-go/api"
@@ -59,6 +60,15 @@ type usernameResponseData struct {
 type usernameResponse struct {
 	GeneralResponse
 	Data usernameResponseData
+}
+
+type getShardResponseData struct {
+	ShardID uint32 `json:"shardID"`
+}
+
+type getShardResponse struct {
+	GeneralResponse
+	Data getShardResponseData
 }
 
 type nonceResponseData struct {
@@ -322,4 +332,67 @@ func TestGetNonce_ReturnsSuccessfully(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.Code)
 	assert.Equal(t, uint64(1), nonceResponse.Data.Nonce)
 	assert.Empty(t, nonceResponse.Error)
+}
+
+// ---- GetShard
+func TestGetShard_FailsWithWrongFacadeTypeConversion(t *testing.T) {
+	t.Parallel()
+
+	ws := startNodeServerWrongFacade()
+	req, _ := http.NewRequest("GET", "/address/address/shard", nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	statusRsp := getShardResponse{}
+	loadResponse(resp.Body, &statusRsp)
+
+	assert.Equal(t, resp.Code, http.StatusInternalServerError)
+	assert.Equal(t, statusRsp.Error, apiErrors.ErrInvalidAppContext.Error())
+}
+
+func TestGetShard_FailWhenFacadeErrors(t *testing.T) {
+	t.Parallel()
+
+	expectedErr := errors.New("cannot compute shard ID")
+	facade := mock.Facade{
+		GetShardIDForAddressHandler: func(_ string) (uint32, error) {
+			return 0, expectedErr
+		},
+	}
+	ws := startNodeServer(&facade)
+
+	reqAddress := "test"
+	req, _ := http.NewRequest("GET", fmt.Sprintf("/address/%s/shard", reqAddress), nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	shardResponse := getShardResponse{}
+	loadResponse(resp.Body, &shardResponse)
+
+	assert.Equal(t, http.StatusInternalServerError, resp.Code)
+	assert.True(t, strings.Contains(shardResponse.Error, expectedErr.Error()))
+}
+
+func TestGetShard_ReturnsSuccessfully(t *testing.T) {
+	t.Parallel()
+
+	expectedShardID := uint32(37)
+	facade := mock.Facade{
+		GetShardIDForAddressHandler: func(_ string) (uint32, error) {
+			return expectedShardID, nil
+		},
+	}
+	ws := startNodeServer(&facade)
+
+	reqAddress := "test"
+	req, _ := http.NewRequest("GET", fmt.Sprintf("/address/%s/shard", reqAddress), nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	shardResponse := getShardResponse{}
+	loadResponse(resp.Body, &shardResponse)
+
+	assert.Equal(t, http.StatusOK, resp.Code)
+	assert.Equal(t, shardResponse.Data.ShardID, expectedShardID)
+	assert.Empty(t, shardResponse.Error)
 }

--- a/api/errors/errors.go
+++ b/api/errors/errors.go
@@ -11,6 +11,9 @@ var ErrInvalidAppContext = errors.New("invalid app context")
 // ErrGetValueForKey signals an error in getting the value of a key for an account
 var ErrGetValueForKey = errors.New("get value for key error")
 
+// ErrComputeShardForAddress signals an error in computing the shard ID for a given address
+var ErrComputeShardForAddress = errors.New("compute shard ID for address error")
+
 // ErrEmptyAddress signals that an empty address was provided
 var ErrEmptyAddress = errors.New("address is empty")
 

--- a/api/hyperblock/interface.go
+++ b/api/hyperblock/interface.go
@@ -4,7 +4,8 @@ import (
 	"github.com/ElrondNetwork/elrond-proxy-go/data"
 )
 
-type facadeHandler interface {
+// FacadeHandler defines the actions needed for fetching the hyperblocks from the nodes
+type FacadeHandler interface {
 	GetHyperBlockByNonce(nonce uint64) (*data.HyperblockApiResponse, error)
 	GetHyperBlockByHash(hash string) (*data.HyperblockApiResponse, error)
 }

--- a/api/hyperblock/routes.go
+++ b/api/hyperblock/routes.go
@@ -18,7 +18,7 @@ func Routes(router *gin.RouterGroup) {
 
 // ByHashHandler handles "by-hash" requests
 func ByHashHandler(c *gin.Context) {
-	epf, ok := c.MustGet("elrondProxyFacade").(facadeHandler)
+	epf, ok := c.MustGet("elrondProxyFacade").(FacadeHandler)
 	if !ok {
 		shared.RespondWithInvalidAppContext(c)
 		return
@@ -42,7 +42,7 @@ func ByHashHandler(c *gin.Context) {
 
 // ByNonceHandler handles "by-nonce" requests
 func ByNonceHandler(c *gin.Context) {
-	epf, ok := c.MustGet("elrondProxyFacade").(facadeHandler)
+	epf, ok := c.MustGet("elrondProxyFacade").(FacadeHandler)
 	if !ok {
 		shared.RespondWithInvalidAppContext(c)
 		return

--- a/api/mock/facade.go
+++ b/api/mock/facade.go
@@ -11,6 +11,7 @@ import (
 type Facade struct {
 	IsFaucetEnabledHandler                      func() bool
 	GetAccountHandler                           func(address string) (*data.Account, error)
+	GetShardIDForAddressHandler                 func(address string) (uint32, error)
 	GetValueForKeyHandler                       func(address string, key string) (string, error)
 	GetTransactionsHandler                      func(address string) ([]data.DatabaseTransaction, error)
 	GetTransactionHandler                       func(txHash string) (*data.FullTransaction, error)
@@ -73,6 +74,11 @@ func (f *Facade) GetAccount(address string) (*data.Account, error) {
 // GetValueForKey -
 func (f *Facade) GetValueForKey(address string, key string) (string, error) {
 	return f.GetValueForKeyHandler(address, key)
+}
+
+// GetShardIDForAddress -
+func (f *Facade) GetShardIDForAddress(address string) (uint32, error) {
+	return f.GetShardIDForAddressHandler(address)
 }
 
 // GetTransactions -

--- a/facade/elrondProxyFacade.go
+++ b/facade/elrondProxyFacade.go
@@ -19,15 +19,15 @@ import (
 )
 
 // interfaces assertions. verifies that all API endpoint have their corresponding methods in the facade
-var _ = address.FacadeHandler(&ElrondProxyFacade{})
-var _ = block.FacadeHandler(&ElrondProxyFacade{})
-var _ = blockatlas.FacadeHandler(&ElrondProxyFacade{})
-var _ = hyperblock.FacadeHandler(&ElrondProxyFacade{})
-var _ = network.FacadeHandler(&ElrondProxyFacade{})
-var _ = node.FacadeHandler(&ElrondProxyFacade{})
-var _ = transaction.FacadeHandler(&ElrondProxyFacade{})
-var _ = validator.FacadeHandler(&ElrondProxyFacade{})
-var _ = vmValues.FacadeHandler(&ElrondProxyFacade{})
+var _ address.FacadeHandler = (*ElrondProxyFacade)(nil)
+var _ block.FacadeHandler = (*ElrondProxyFacade)(nil)
+var _ blockatlas.FacadeHandler = (*ElrondProxyFacade)(nil)
+var _ hyperblock.FacadeHandler = (*ElrondProxyFacade)(nil)
+var _ network.FacadeHandler = (*ElrondProxyFacade)(nil)
+var _ node.FacadeHandler = (*ElrondProxyFacade)(nil)
+var _ transaction.FacadeHandler = (*ElrondProxyFacade)(nil)
+var _ validator.FacadeHandler = (*ElrondProxyFacade)(nil)
+var _ vmValues.FacadeHandler = (*ElrondProxyFacade)(nil)
 
 // ElrondProxyFacade implements the facade used in api calls
 type ElrondProxyFacade struct {
@@ -100,7 +100,7 @@ func (epf *ElrondProxyFacade) GetValueForKey(address string, key string) (string
 	return epf.accountProc.GetValueForKey(address, key)
 }
 
-// GetShardForAddress returns the computed shard ID for the given address based on the current proxy's configuration
+// GetShardIDForAddress returns the computed shard ID for the given address based on the current proxy's configuration
 func (epf *ElrondProxyFacade) GetShardIDForAddress(address string) (uint32, error) {
 	return epf.accountProc.GetShardIDForAddress(address)
 }

--- a/facade/elrondProxyFacade.go
+++ b/facade/elrondProxyFacade.go
@@ -5,9 +5,29 @@ import (
 	"math/big"
 
 	"github.com/ElrondNetwork/elrond-go/core"
+	"github.com/ElrondNetwork/elrond-proxy-go/api/address"
+	"github.com/ElrondNetwork/elrond-proxy-go/api/block"
+	"github.com/ElrondNetwork/elrond-proxy-go/api/blockatlas"
+	"github.com/ElrondNetwork/elrond-proxy-go/api/hyperblock"
+	"github.com/ElrondNetwork/elrond-proxy-go/api/network"
+	"github.com/ElrondNetwork/elrond-proxy-go/api/node"
+	"github.com/ElrondNetwork/elrond-proxy-go/api/transaction"
+	"github.com/ElrondNetwork/elrond-proxy-go/api/validator"
+	"github.com/ElrondNetwork/elrond-proxy-go/api/vmValues"
 	"github.com/ElrondNetwork/elrond-proxy-go/data"
 	vmcommon "github.com/ElrondNetwork/elrond-vm-common"
 )
+
+// interfaces assertions. verifies that all API endpoint have their corresponding methods in the facade
+var _ = address.FacadeHandler(&ElrondProxyFacade{})
+var _ = block.FacadeHandler(&ElrondProxyFacade{})
+var _ = blockatlas.FacadeHandler(&ElrondProxyFacade{})
+var _ = hyperblock.FacadeHandler(&ElrondProxyFacade{})
+var _ = network.FacadeHandler(&ElrondProxyFacade{})
+var _ = node.FacadeHandler(&ElrondProxyFacade{})
+var _ = transaction.FacadeHandler(&ElrondProxyFacade{})
+var _ = validator.FacadeHandler(&ElrondProxyFacade{})
+var _ = vmValues.FacadeHandler(&ElrondProxyFacade{})
 
 // ElrondProxyFacade implements the facade used in api calls
 type ElrondProxyFacade struct {
@@ -78,6 +98,11 @@ func (epf *ElrondProxyFacade) GetAccount(address string) (*data.Account, error) 
 // GetValueForKey returns the value for the given address and key
 func (epf *ElrondProxyFacade) GetValueForKey(address string, key string) (string, error) {
 	return epf.accountProc.GetValueForKey(address, key)
+}
+
+// GetShardForAddress returns the computed shard ID for the given address based on the current proxy's configuration
+func (epf *ElrondProxyFacade) GetShardIDForAddress(address string) (uint32, error) {
+	return epf.accountProc.GetShardIDForAddress(address)
 }
 
 // GetTransactions returns transactions by address

--- a/facade/interface.go
+++ b/facade/interface.go
@@ -11,6 +11,7 @@ import (
 // AccountProcessor defines what an account request processor should do
 type AccountProcessor interface {
 	GetAccount(address string) (*data.Account, error)
+	GetShardIDForAddress(address string) (uint32, error)
 	GetValueForKey(address string, key string) (string, error)
 	GetTransactions(address string) ([]data.DatabaseTransaction, error)
 }

--- a/facade/mock/accountProccessorStub.go
+++ b/facade/mock/accountProccessorStub.go
@@ -6,10 +6,11 @@ import (
 
 // AccountProcessorStub --
 type AccountProcessorStub struct {
-	GetAccountCalled          func(address string) (*data.Account, error)
-	GetValueForKeyCalled      func(address string, key string) (string, error)
-	GetTransactionsCalled     func(address string) ([]data.DatabaseTransaction, error)
-	ValidatorStatisticsCalled func() (map[string]*data.ValidatorApiResponse, error)
+	GetAccountCalled           func(address string) (*data.Account, error)
+	GetValueForKeyCalled       func(address string, key string) (string, error)
+	GetShardIDForAddressCalled func(address string) (uint32, error)
+	GetTransactionsCalled      func(address string) ([]data.DatabaseTransaction, error)
+	ValidatorStatisticsCalled  func() (map[string]*data.ValidatorApiResponse, error)
 }
 
 // GetAccount --
@@ -20,6 +21,11 @@ func (aps *AccountProcessorStub) GetAccount(address string) (*data.Account, erro
 // GetValueForKey --
 func (aps *AccountProcessorStub) GetValueForKey(address string, key string) (string, error) {
 	return aps.GetValueForKeyCalled(address, key)
+}
+
+// GetShardIDForAddress --
+func (aps *AccountProcessorStub) GetShardIDForAddress(address string) (uint32, error) {
+	return aps.GetShardIDForAddressCalled(address)
 }
 
 // GetTransactions --

--- a/process/accountProcessor.go
+++ b/process/accountProcessor.go
@@ -38,7 +38,7 @@ func NewAccountProcessor(proc Processor, pubKeyConverter core.PubkeyConverter, c
 	}, nil
 }
 
-// GetShardForAddress resolves the request by returning the shard ID for a given address for the current proxy's configuration
+// GetShardIDForAddress resolves the request by returning the shard ID for a given address for the current proxy's configuration
 func (ap *AccountProcessor) GetShardIDForAddress(address string) (uint32, error) {
 	addressBytes, err := ap.pubKeyConverter.Decode(address)
 	if err != nil {

--- a/process/accountProcessor.go
+++ b/process/accountProcessor.go
@@ -38,6 +38,16 @@ func NewAccountProcessor(proc Processor, pubKeyConverter core.PubkeyConverter, c
 	}, nil
 }
 
+// GetShardForAddress resolves the request by returning the shard ID for a given address for the current proxy's configuration
+func (ap *AccountProcessor) GetShardIDForAddress(address string) (uint32, error) {
+	addressBytes, err := ap.pubKeyConverter.Decode(address)
+	if err != nil {
+		return 0, err
+	}
+
+	return ap.proc.ComputeShardId(addressBytes)
+}
+
 // GetAccount resolves the request by sending the request to the right observer and replies back the answer
 func (ap *AccountProcessor) GetAccount(address string) (*data.Account, error) {
 	observers, err := ap.getObserversForAddress(address)

--- a/process/accountProcessor_test.go
+++ b/process/accountProcessor_test.go
@@ -270,14 +270,6 @@ func TestAccountProcessor_GetShardIDForAddressShouldError(t *testing.T) {
 	ap, _ := process.NewAccountProcessor(
 		&mock.ProcessorStub{
 			ComputeShardIdCalled: func(addressBuff []byte) (u uint32, e error) {
-				return 0, nil
-			},
-			GetObserversCalled: func(shardId uint32) (observers []*data.NodeData, e error) {
-				return []*data.NodeData{
-					{Address: "address", ShardId: 0},
-				}, nil
-			},
-			CallGetRestEndPointCalled: func(address string, path string, value interface{}) (int, error) {
 				return 0, expectedError
 			},
 		},
@@ -285,9 +277,7 @@ func TestAccountProcessor_GetShardIDForAddressShouldError(t *testing.T) {
 		database.NewDisabledElasticSearchConnector(),
 	)
 
-	key := "key"
-	addr1 := "DEADBEEF"
-	value, err := ap.GetValueForKey(addr1, key)
-	assert.Equal(t, "", value)
-	assert.Equal(t, process.ErrSendingRequest, err)
+	shardID, err := ap.GetShardIDForAddress("aaaa")
+	assert.Equal(t, uint32(0), shardID)
+	assert.Equal(t, expectedError, err)
 }


### PR DESCRIPTION
Added an API endpoint that will compute the shard ID for a given address (based on the current proxy's configuration).

Testing procedure:
-> run a testnet and configure the proxy for it
-> make GET requests to `/address/erd1../shard` and it should return the correct shard ID