### PR TITLE
Extra check for hyperblocks

### DIFF
--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -393,7 +393,7 @@ func createFacade(
 		return nil, err
 	}
 
-	blockProc, err := process.NewBlockProcessor(connector, bp)
+	blockProc, err := process.NewBlockProcessor(connector, bp, nodeStatusProc.GetLatestFullySynchronizedHyperblockNonce)
 	if err != nil {
 		return nil, err
 	}

--- a/process/blockProcessor.go
+++ b/process/blockProcessor.go
@@ -2,7 +2,6 @@ package process
 
 import (
 	"fmt"
-	"math"
 
 	"github.com/ElrondNetwork/elrond-go/core"
 	"github.com/ElrondNetwork/elrond-go/core/check"
@@ -33,11 +32,8 @@ func NewBlockProcessor(
 	if check.IfNil(proc) {
 		return nil, ErrNilCoreProcessor
 	}
-	// if function is nil will return always MaxUint64 -> result of function will be ignored
 	if getLatestFullySynchronizedHyperblockNonce == nil {
-		getLatestFullySynchronizedHyperblockNonce = func() (uint64, error) {
-			return uint64(math.MaxUint64), nil
-		}
+		return nil, ErrNilGetLatestFullySynchronizedHyperblockNonceFunction
 	}
 
 	return &blockProcessor{

--- a/process/blockProcessor_test.go
+++ b/process/blockProcessor_test.go
@@ -3,6 +3,7 @@ package process_test
 import (
 	"errors"
 	"fmt"
+	"math"
 	"strings"
 	"testing"
 
@@ -12,10 +13,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func getLatestFullySynchronizedHyperblockNonceMock() (uint64, error) {
+	return math.MaxUint64, nil
+}
+
 func TestNewBlockProcessor_NilExternalStorageConnectorShouldErr(t *testing.T) {
 	t.Parallel()
 
-	bp, err := process.NewBlockProcessor(nil, &mock.ProcessorStub{}, nil)
+	bp, err := process.NewBlockProcessor(nil, &mock.ProcessorStub{}, getLatestFullySynchronizedHyperblockNonceMock)
 	require.Nil(t, bp)
 	require.Equal(t, process.ErrNilDatabaseConnector, err)
 }
@@ -23,15 +28,23 @@ func TestNewBlockProcessor_NilExternalStorageConnectorShouldErr(t *testing.T) {
 func TestNewBlockProcessor_NilProcessorShouldErr(t *testing.T) {
 	t.Parallel()
 
-	bp, err := process.NewBlockProcessor(&mock.ExternalStorageConnectorStub{}, nil, nil)
+	bp, err := process.NewBlockProcessor(&mock.ExternalStorageConnectorStub{}, nil, getLatestFullySynchronizedHyperblockNonceMock)
 	require.Nil(t, bp)
 	require.Equal(t, process.ErrNilCoreProcessor, err)
+}
+
+func TestNewBlockProcessor_ErrNilFuncToGetLatestFullySynchronizedHyberblockNonce(t *testing.T) {
+	t.Parallel()
+
+	bp, err := process.NewBlockProcessor(&mock.ExternalStorageConnectorStub{}, &mock.ProcessorStub{}, nil)
+	require.Nil(t, bp)
+	require.Equal(t, process.ErrNilGetLatestFullySynchronizedHyperblockNonceFunction, err)
 }
 
 func TestNewBlockProcessor_ShouldWork(t *testing.T) {
 	t.Parallel()
 
-	bp, err := process.NewBlockProcessor(&mock.ExternalStorageConnectorStub{}, &mock.ProcessorStub{}, nil)
+	bp, err := process.NewBlockProcessor(&mock.ExternalStorageConnectorStub{}, &mock.ProcessorStub{}, getLatestFullySynchronizedHyperblockNonceMock)
 	require.NotNil(t, bp)
 	require.NoError(t, err)
 }
@@ -39,7 +52,7 @@ func TestNewBlockProcessor_ShouldWork(t *testing.T) {
 func TestBlockProcessor_GetAtlasBlockByShardIDAndNonce(t *testing.T) {
 	t.Parallel()
 
-	bp, _ := process.NewBlockProcessor(&mock.ExternalStorageConnectorStub{}, &mock.ProcessorStub{}, nil)
+	bp, _ := process.NewBlockProcessor(&mock.ExternalStorageConnectorStub{}, &mock.ProcessorStub{}, getLatestFullySynchronizedHyperblockNonceMock)
 	require.NotNil(t, bp)
 
 	res, err := bp.GetAtlasBlockByShardIDAndNonce(0, 1)
@@ -64,7 +77,7 @@ func TestBlockProcessor_GetBlockByHashShouldGetFullHistoryNodes(t *testing.T) {
 		},
 	}
 
-	bp, _ := process.NewBlockProcessor(&mock.ExternalStorageConnectorStub{}, proc, nil)
+	bp, _ := process.NewBlockProcessor(&mock.ExternalStorageConnectorStub{}, proc, getLatestFullySynchronizedHyperblockNonceMock)
 	require.NotNil(t, bp)
 
 	_, _ = bp.GetBlockByHash(0, "hash", false)
@@ -90,7 +103,7 @@ func TestBlockProcessor_GetBlockByHashShouldGetObservers(t *testing.T) {
 		},
 	}
 
-	bp, _ := process.NewBlockProcessor(&mock.ExternalStorageConnectorStub{}, proc, nil)
+	bp, _ := process.NewBlockProcessor(&mock.ExternalStorageConnectorStub{}, proc, getLatestFullySynchronizedHyperblockNonceMock)
 	require.NotNil(t, bp)
 
 	_, _ = bp.GetBlockByHash(0, "hash", false)
@@ -112,7 +125,7 @@ func TestBlockProcessor_GetBlockByHashNoFullNodesOrObserversShouldErr(t *testing
 		},
 	}
 
-	bp, _ := process.NewBlockProcessor(&mock.ExternalStorageConnectorStub{}, proc, nil)
+	bp, _ := process.NewBlockProcessor(&mock.ExternalStorageConnectorStub{}, proc, getLatestFullySynchronizedHyperblockNonceMock)
 	require.NotNil(t, bp)
 
 	res, err := bp.GetBlockByHash(0, "hash", false)
@@ -133,7 +146,7 @@ func TestBlockProcessor_GetBlockByHashCallGetFailsShouldErr(t *testing.T) {
 		},
 	}
 
-	bp, _ := process.NewBlockProcessor(&mock.ExternalStorageConnectorStub{}, proc, nil)
+	bp, _ := process.NewBlockProcessor(&mock.ExternalStorageConnectorStub{}, proc, getLatestFullySynchronizedHyperblockNonceMock)
 	require.NotNil(t, bp)
 
 	res, err := bp.GetBlockByHash(0, "hash", false)
@@ -156,7 +169,7 @@ func TestBlockProcessor_GetBlockByHashShouldWork(t *testing.T) {
 		},
 	}
 
-	bp, _ := process.NewBlockProcessor(&mock.ExternalStorageConnectorStub{}, proc, nil)
+	bp, _ := process.NewBlockProcessor(&mock.ExternalStorageConnectorStub{}, proc, getLatestFullySynchronizedHyperblockNonceMock)
 	require.NotNil(t, bp)
 
 	res, err := bp.GetBlockByHash(0, "hash", false)
@@ -184,7 +197,7 @@ func TestBlockProcessor_GetBlockByHashShouldWorkAndIncludeAlsoTxs(t *testing.T) 
 		},
 	}
 
-	bp, _ := process.NewBlockProcessor(&mock.ExternalStorageConnectorStub{}, proc, nil)
+	bp, _ := process.NewBlockProcessor(&mock.ExternalStorageConnectorStub{}, proc, getLatestFullySynchronizedHyperblockNonceMock)
 	require.NotNil(t, bp)
 
 	res, err := bp.GetBlockByHash(0, "hash", true)
@@ -213,7 +226,7 @@ func TestBlockProcessor_GetBlockByNonceShouldGetFullHistoryNodes(t *testing.T) {
 		},
 	}
 
-	bp, _ := process.NewBlockProcessor(&mock.ExternalStorageConnectorStub{}, proc, nil)
+	bp, _ := process.NewBlockProcessor(&mock.ExternalStorageConnectorStub{}, proc, getLatestFullySynchronizedHyperblockNonceMock)
 	require.NotNil(t, bp)
 
 	_, _ = bp.GetBlockByNonce(0, 0, false)
@@ -239,7 +252,7 @@ func TestBlockProcessor_GetBlockByNonceShouldGetObservers(t *testing.T) {
 		},
 	}
 
-	bp, _ := process.NewBlockProcessor(&mock.ExternalStorageConnectorStub{}, proc, nil)
+	bp, _ := process.NewBlockProcessor(&mock.ExternalStorageConnectorStub{}, proc, getLatestFullySynchronizedHyperblockNonceMock)
 	require.NotNil(t, bp)
 
 	_, _ = bp.GetBlockByNonce(0, 1, false)
@@ -261,7 +274,7 @@ func TestBlockProcessor_GetBlockByNonceNoFullNodesOrObserversShouldErr(t *testin
 		},
 	}
 
-	bp, _ := process.NewBlockProcessor(&mock.ExternalStorageConnectorStub{}, proc, nil)
+	bp, _ := process.NewBlockProcessor(&mock.ExternalStorageConnectorStub{}, proc, getLatestFullySynchronizedHyperblockNonceMock)
 	require.NotNil(t, bp)
 
 	res, err := bp.GetBlockByNonce(0, 1, false)
@@ -282,7 +295,7 @@ func TestBlockProcessor_GetBlockByNonceCallGetFailsShouldErr(t *testing.T) {
 		},
 	}
 
-	bp, _ := process.NewBlockProcessor(&mock.ExternalStorageConnectorStub{}, proc, nil)
+	bp, _ := process.NewBlockProcessor(&mock.ExternalStorageConnectorStub{}, proc, getLatestFullySynchronizedHyperblockNonceMock)
 	require.NotNil(t, bp)
 
 	res, err := bp.GetBlockByNonce(0, 0, false)
@@ -305,7 +318,7 @@ func TestBlockProcessor_GetBlockByNonceShouldWork(t *testing.T) {
 		},
 	}
 
-	bp, _ := process.NewBlockProcessor(&mock.ExternalStorageConnectorStub{}, proc, nil)
+	bp, _ := process.NewBlockProcessor(&mock.ExternalStorageConnectorStub{}, proc, getLatestFullySynchronizedHyperblockNonceMock)
 	require.NotNil(t, bp)
 
 	res, err := bp.GetBlockByNonce(0, nonce, false)
@@ -333,7 +346,7 @@ func TestBlockProcessor_GetBlockByNonceShouldWorkAndIncludeAlsoTxs(t *testing.T)
 		},
 	}
 
-	bp, _ := process.NewBlockProcessor(&mock.ExternalStorageConnectorStub{}, proc, nil)
+	bp, _ := process.NewBlockProcessor(&mock.ExternalStorageConnectorStub{}, proc, getLatestFullySynchronizedHyperblockNonceMock)
 	require.NotNil(t, bp)
 
 	res, err := bp.GetBlockByNonce(0, 3, true)
@@ -372,7 +385,7 @@ func TestBlockProcessor_GetHyperBlock(t *testing.T) {
 		},
 	}
 
-	processor, err := process.NewBlockProcessor(&mock.ExternalStorageConnectorStub{}, proc, nil)
+	processor, err := process.NewBlockProcessor(&mock.ExternalStorageConnectorStub{}, proc, getLatestFullySynchronizedHyperblockNonceMock)
 	require.Nil(t, err)
 	require.NotNil(t, processor)
 

--- a/process/blockProcessor_test.go
+++ b/process/blockProcessor_test.go
@@ -15,7 +15,7 @@ import (
 func TestNewBlockProcessor_NilExternalStorageConnectorShouldErr(t *testing.T) {
 	t.Parallel()
 
-	bp, err := process.NewBlockProcessor(nil, &mock.ProcessorStub{})
+	bp, err := process.NewBlockProcessor(nil, &mock.ProcessorStub{}, nil)
 	require.Nil(t, bp)
 	require.Equal(t, process.ErrNilDatabaseConnector, err)
 }
@@ -23,7 +23,7 @@ func TestNewBlockProcessor_NilExternalStorageConnectorShouldErr(t *testing.T) {
 func TestNewBlockProcessor_NilProcessorShouldErr(t *testing.T) {
 	t.Parallel()
 
-	bp, err := process.NewBlockProcessor(&mock.ExternalStorageConnectorStub{}, nil)
+	bp, err := process.NewBlockProcessor(&mock.ExternalStorageConnectorStub{}, nil, nil)
 	require.Nil(t, bp)
 	require.Equal(t, process.ErrNilCoreProcessor, err)
 }
@@ -31,7 +31,7 @@ func TestNewBlockProcessor_NilProcessorShouldErr(t *testing.T) {
 func TestNewBlockProcessor_ShouldWork(t *testing.T) {
 	t.Parallel()
 
-	bp, err := process.NewBlockProcessor(&mock.ExternalStorageConnectorStub{}, &mock.ProcessorStub{})
+	bp, err := process.NewBlockProcessor(&mock.ExternalStorageConnectorStub{}, &mock.ProcessorStub{}, nil)
 	require.NotNil(t, bp)
 	require.NoError(t, err)
 }
@@ -39,7 +39,7 @@ func TestNewBlockProcessor_ShouldWork(t *testing.T) {
 func TestBlockProcessor_GetAtlasBlockByShardIDAndNonce(t *testing.T) {
 	t.Parallel()
 
-	bp, _ := process.NewBlockProcessor(&mock.ExternalStorageConnectorStub{}, &mock.ProcessorStub{})
+	bp, _ := process.NewBlockProcessor(&mock.ExternalStorageConnectorStub{}, &mock.ProcessorStub{}, nil)
 	require.NotNil(t, bp)
 
 	res, err := bp.GetAtlasBlockByShardIDAndNonce(0, 1)
@@ -64,7 +64,7 @@ func TestBlockProcessor_GetBlockByHashShouldGetFullHistoryNodes(t *testing.T) {
 		},
 	}
 
-	bp, _ := process.NewBlockProcessor(&mock.ExternalStorageConnectorStub{}, proc)
+	bp, _ := process.NewBlockProcessor(&mock.ExternalStorageConnectorStub{}, proc, nil)
 	require.NotNil(t, bp)
 
 	_, _ = bp.GetBlockByHash(0, "hash", false)
@@ -90,7 +90,7 @@ func TestBlockProcessor_GetBlockByHashShouldGetObservers(t *testing.T) {
 		},
 	}
 
-	bp, _ := process.NewBlockProcessor(&mock.ExternalStorageConnectorStub{}, proc)
+	bp, _ := process.NewBlockProcessor(&mock.ExternalStorageConnectorStub{}, proc, nil)
 	require.NotNil(t, bp)
 
 	_, _ = bp.GetBlockByHash(0, "hash", false)
@@ -112,7 +112,7 @@ func TestBlockProcessor_GetBlockByHashNoFullNodesOrObserversShouldErr(t *testing
 		},
 	}
 
-	bp, _ := process.NewBlockProcessor(&mock.ExternalStorageConnectorStub{}, proc)
+	bp, _ := process.NewBlockProcessor(&mock.ExternalStorageConnectorStub{}, proc, nil)
 	require.NotNil(t, bp)
 
 	res, err := bp.GetBlockByHash(0, "hash", false)
@@ -133,7 +133,7 @@ func TestBlockProcessor_GetBlockByHashCallGetFailsShouldErr(t *testing.T) {
 		},
 	}
 
-	bp, _ := process.NewBlockProcessor(&mock.ExternalStorageConnectorStub{}, proc)
+	bp, _ := process.NewBlockProcessor(&mock.ExternalStorageConnectorStub{}, proc, nil)
 	require.NotNil(t, bp)
 
 	res, err := bp.GetBlockByHash(0, "hash", false)
@@ -156,7 +156,7 @@ func TestBlockProcessor_GetBlockByHashShouldWork(t *testing.T) {
 		},
 	}
 
-	bp, _ := process.NewBlockProcessor(&mock.ExternalStorageConnectorStub{}, proc)
+	bp, _ := process.NewBlockProcessor(&mock.ExternalStorageConnectorStub{}, proc, nil)
 	require.NotNil(t, bp)
 
 	res, err := bp.GetBlockByHash(0, "hash", false)
@@ -184,7 +184,7 @@ func TestBlockProcessor_GetBlockByHashShouldWorkAndIncludeAlsoTxs(t *testing.T) 
 		},
 	}
 
-	bp, _ := process.NewBlockProcessor(&mock.ExternalStorageConnectorStub{}, proc)
+	bp, _ := process.NewBlockProcessor(&mock.ExternalStorageConnectorStub{}, proc, nil)
 	require.NotNil(t, bp)
 
 	res, err := bp.GetBlockByHash(0, "hash", true)
@@ -213,7 +213,7 @@ func TestBlockProcessor_GetBlockByNonceShouldGetFullHistoryNodes(t *testing.T) {
 		},
 	}
 
-	bp, _ := process.NewBlockProcessor(&mock.ExternalStorageConnectorStub{}, proc)
+	bp, _ := process.NewBlockProcessor(&mock.ExternalStorageConnectorStub{}, proc, nil)
 	require.NotNil(t, bp)
 
 	_, _ = bp.GetBlockByNonce(0, 0, false)
@@ -239,7 +239,7 @@ func TestBlockProcessor_GetBlockByNonceShouldGetObservers(t *testing.T) {
 		},
 	}
 
-	bp, _ := process.NewBlockProcessor(&mock.ExternalStorageConnectorStub{}, proc)
+	bp, _ := process.NewBlockProcessor(&mock.ExternalStorageConnectorStub{}, proc, nil)
 	require.NotNil(t, bp)
 
 	_, _ = bp.GetBlockByNonce(0, 1, false)
@@ -261,7 +261,7 @@ func TestBlockProcessor_GetBlockByNonceNoFullNodesOrObserversShouldErr(t *testin
 		},
 	}
 
-	bp, _ := process.NewBlockProcessor(&mock.ExternalStorageConnectorStub{}, proc)
+	bp, _ := process.NewBlockProcessor(&mock.ExternalStorageConnectorStub{}, proc, nil)
 	require.NotNil(t, bp)
 
 	res, err := bp.GetBlockByNonce(0, 1, false)
@@ -282,7 +282,7 @@ func TestBlockProcessor_GetBlockByNonceCallGetFailsShouldErr(t *testing.T) {
 		},
 	}
 
-	bp, _ := process.NewBlockProcessor(&mock.ExternalStorageConnectorStub{}, proc)
+	bp, _ := process.NewBlockProcessor(&mock.ExternalStorageConnectorStub{}, proc, nil)
 	require.NotNil(t, bp)
 
 	res, err := bp.GetBlockByNonce(0, 0, false)
@@ -305,7 +305,7 @@ func TestBlockProcessor_GetBlockByNonceShouldWork(t *testing.T) {
 		},
 	}
 
-	bp, _ := process.NewBlockProcessor(&mock.ExternalStorageConnectorStub{}, proc)
+	bp, _ := process.NewBlockProcessor(&mock.ExternalStorageConnectorStub{}, proc, nil)
 	require.NotNil(t, bp)
 
 	res, err := bp.GetBlockByNonce(0, nonce, false)
@@ -333,7 +333,7 @@ func TestBlockProcessor_GetBlockByNonceShouldWorkAndIncludeAlsoTxs(t *testing.T)
 		},
 	}
 
-	bp, _ := process.NewBlockProcessor(&mock.ExternalStorageConnectorStub{}, proc)
+	bp, _ := process.NewBlockProcessor(&mock.ExternalStorageConnectorStub{}, proc, nil)
 	require.NotNil(t, bp)
 
 	res, err := bp.GetBlockByNonce(0, 3, true)
@@ -372,7 +372,7 @@ func TestBlockProcessor_GetHyperBlock(t *testing.T) {
 		},
 	}
 
-	processor, err := process.NewBlockProcessor(&mock.ExternalStorageConnectorStub{}, proc)
+	processor, err := process.NewBlockProcessor(&mock.ExternalStorageConnectorStub{}, proc, nil)
 	require.Nil(t, err)
 	require.NotNil(t, processor)
 
@@ -391,4 +391,48 @@ func TestBlockProcessor_GetHyperBlock(t *testing.T) {
 	require.Equal(t, 4, numGetBlockCalled, "get block should be called for metablock and for all notarized shard blocks")
 	require.Equal(t, 42, int(response.Data.Hyperblock.Nonce))
 	require.Equal(t, "abcd", response.Data.Hyperblock.Hash)
+}
+
+func TestBlockProcessor_GetHyperBlockByHash_NonceIsTooHigh(t *testing.T) {
+	t.Parallel()
+
+	proc := &mock.ProcessorStub{
+		GetFullHistoryNodesCalled: func(shardId uint32) ([]*data.NodeData, error) {
+			return []*data.NodeData{{ShardId: shardId, Address: fmt.Sprintf("http://observer-%d", shardId)}}, nil
+		},
+		CallGetRestEndPointCalled: func(address string, path string, value interface{}) (int, error) {
+			response := value.(*data.BlockApiResponse)
+			response.Data = data.BlockApiResponsePayload{Block: data.Block{Nonce: 42}}
+
+			return 200, nil
+		},
+	}
+
+	getLatestFullySynchronizedHyperblockNonce := func() (uint64, error) {
+		return 1, nil
+	}
+	processor, err := process.NewBlockProcessor(&mock.ExternalStorageConnectorStub{}, proc, getLatestFullySynchronizedHyperblockNonce)
+	require.Nil(t, err)
+	require.NotNil(t, processor)
+
+	response, err := processor.GetHyperBlockByHash("abcd")
+	require.Nil(t, response)
+	require.True(t, errors.Is(err, process.ErrCannotGetHyperblock))
+}
+
+func TestBlockProcessor_GetHyperBlockByNonce_NonceIsTooHigh(t *testing.T) {
+	t.Parallel()
+
+	proc := &mock.ProcessorStub{}
+
+	getLatestFullySynchronizedHyperblockNonce := func() (uint64, error) {
+		return 1, nil
+	}
+	processor, err := process.NewBlockProcessor(&mock.ExternalStorageConnectorStub{}, proc, getLatestFullySynchronizedHyperblockNonce)
+	require.Nil(t, err)
+	require.NotNil(t, processor)
+
+	response, err := processor.GetHyperBlockByNonce(10)
+	require.Nil(t, response)
+	require.True(t, errors.Is(err, process.ErrCannotGetHyperblock))
 }

--- a/process/errors.go
+++ b/process/errors.go
@@ -85,3 +85,6 @@ var ErrInvalidSignatureBytes = errors.New("invalid signatures bytes")
 
 // ErrCannotGetHyperblock signal that hypeblock cannot be returned
 var ErrCannotGetHyperblock = errors.New("cannot get hyberblock")
+
+// ErrNilGetLatestFullySynchronizedHyperblockNonceFunction signals that function to get latest fully synchronized hyberblock is nil
+var ErrNilGetLatestFullySynchronizedHyperblockNonceFunction = errors.New("signals that a nil function for get latest fully synchronized hyberblock is provided")

--- a/process/errors.go
+++ b/process/errors.go
@@ -82,3 +82,6 @@ var ErrInvalidAddress = errors.New("could not create address from provided param
 
 // ErrInvalidSignatureBytes signal that an invalid signature hash been provided
 var ErrInvalidSignatureBytes = errors.New("invalid signatures bytes")
+
+// ErrCannotGetHyperblock signal that hypeblock cannot be returned
+var ErrCannotGetHyperblock = errors.New("cannot get hyberblock")


### PR DESCRIPTION
When a hyperblock needs to be build an extra check was added. 
Now we verify if the observers can return all the blocks that are needed for hyperblock.
This check is needed because if one observer is not synchronized hyperblock cannot be constructed and we need a more specific error.