### PR TITLE
fix api route /address/:addr/transactions

### DIFF
--- a/process/accountProcessor.go
+++ b/process/accountProcessor.go
@@ -163,6 +163,10 @@ func (ap *AccountProcessor) GetAllESDTTokens(address string) (*data.GenericAPIRe
 
 // GetTransactions resolves the request and returns a slice of transaction for the specific address
 func (ap *AccountProcessor) GetTransactions(address string) ([]data.DatabaseTransaction, error) {
+	if _, err := ap.pubKeyConverter.Decode(address); err != nil {
+		return nil, ErrInvalidAddress
+	}
+
 	return ap.connector.GetTransactionsByAddress(address)
 }
 

--- a/process/accountProcessor.go
+++ b/process/accountProcessor.go
@@ -2,6 +2,7 @@ package process
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/ElrondNetwork/elrond-go/core"
@@ -164,7 +165,7 @@ func (ap *AccountProcessor) GetAllESDTTokens(address string) (*data.GenericAPIRe
 // GetTransactions resolves the request and returns a slice of transaction for the specific address
 func (ap *AccountProcessor) GetTransactions(address string) ([]data.DatabaseTransaction, error) {
 	if _, err := ap.pubKeyConverter.Decode(address); err != nil {
-		return nil, ErrInvalidAddress
+		return nil, fmt.Errorf("%w, %v", ErrInvalidAddress, err)
 	}
 
 	return ap.connector.GetTransactionsByAddress(address)

--- a/process/accountProcessor_test.go
+++ b/process/accountProcessor_test.go
@@ -2,6 +2,8 @@ package process_test
 
 import (
 	"errors"
+	"github.com/ElrondNetwork/elrond-go/config"
+	"github.com/ElrondNetwork/elrond-go/data/state/factory"
 	"testing"
 
 	"github.com/ElrondNetwork/elrond-go/core/pubkeyConverter"
@@ -280,4 +282,24 @@ func TestAccountProcessor_GetShardIDForAddressShouldError(t *testing.T) {
 	shardID, err := ap.GetShardIDForAddress("aaaa")
 	assert.Equal(t, uint32(0), shardID)
 	assert.Equal(t, expectedError, err)
+}
+
+func TestAccountProcessor_GetTransactionsInvalidAddrShouldErr(t *testing.T) {
+	t.Parallel()
+
+	converter, _ := factory.NewPubkeyConverter(config.PubkeyConfig{
+		Length: 32,
+		Type:   "bech32",
+	})
+	ap, _ := process.NewAccountProcessor(
+		&mock.ProcessorStub{},
+		converter,
+		database.NewDisabledElasticSearchConnector(),
+	)
+
+	_, err := ap.GetTransactions("invalidAddress")
+	assert.Equal(t, process.ErrInvalidAddress, err)
+
+	_, err = ap.GetTransactions("")
+	assert.Equal(t, process.ErrInvalidAddress, err)
 }

--- a/process/accountProcessor_test.go
+++ b/process/accountProcessor_test.go
@@ -2,11 +2,11 @@ package process_test
 
 import (
 	"errors"
-	"github.com/ElrondNetwork/elrond-go/config"
-	"github.com/ElrondNetwork/elrond-go/data/state/factory"
 	"testing"
 
+	"github.com/ElrondNetwork/elrond-go/config"
 	"github.com/ElrondNetwork/elrond-go/core/pubkeyConverter"
+	"github.com/ElrondNetwork/elrond-go/data/state/factory"
 	"github.com/ElrondNetwork/elrond-go/sharding"
 	"github.com/ElrondNetwork/elrond-proxy-go/data"
 	"github.com/ElrondNetwork/elrond-proxy-go/process"
@@ -298,8 +298,8 @@ func TestAccountProcessor_GetTransactionsInvalidAddrShouldErr(t *testing.T) {
 	)
 
 	_, err := ap.GetTransactions("invalidAddress")
-	assert.Equal(t, process.ErrInvalidAddress, err)
+	assert.True(t, errors.Is(err, process.ErrInvalidAddress))
 
 	_, err = ap.GetTransactions("")
-	assert.Equal(t, process.ErrInvalidAddress, err)
+	assert.True(t, errors.Is(err, process.ErrInvalidAddress))
 }

--- a/process/accountProcessor_test.go
+++ b/process/accountProcessor_test.go
@@ -284,7 +284,7 @@ func TestAccountProcessor_GetShardIDForAddressShouldError(t *testing.T) {
 	assert.Equal(t, expectedError, err)
 }
 
-func TestAccountProcessor_GetTransactionsInvalidAddrShouldErr(t *testing.T) {
+func TestAccountProcessor_GetTransactions(t *testing.T) {
 	t.Parallel()
 
 	converter, _ := factory.NewPubkeyConverter(config.PubkeyConfig{
@@ -294,7 +294,7 @@ func TestAccountProcessor_GetTransactionsInvalidAddrShouldErr(t *testing.T) {
 	ap, _ := process.NewAccountProcessor(
 		&mock.ProcessorStub{},
 		converter,
-		database.NewDisabledElasticSearchConnector(),
+		&mock.ElasticSearchConnectorMock{},
 	)
 
 	_, err := ap.GetTransactions("invalidAddress")
@@ -302,4 +302,7 @@ func TestAccountProcessor_GetTransactionsInvalidAddrShouldErr(t *testing.T) {
 
 	_, err = ap.GetTransactions("")
 	assert.True(t, errors.Is(err, process.ErrInvalidAddress))
+
+	_, err = ap.GetTransactions("erd1ycega644rvjtgtyd8hfzt6hl5ymaa8ml2nhhs5cv045cz5vxm00q022myr")
+	assert.Nil(t, err)
 }

--- a/process/database/elasticSearchConnector.go
+++ b/process/database/elasticSearchConnector.go
@@ -151,10 +151,11 @@ func (esc *elasticSearchConnector) doSearchRequest(query object, index string, s
 }
 
 func (esc *elasticSearchConnector) doSearchRequestTx(address string, index string, size int) (object, error) {
+	query := fmt.Sprintf("sender:%s OR receiver:%s", address, address)
 	res, err := esc.client.Search(
 		esc.client.Search.WithIndex(index),
 		esc.client.Search.WithSize(size),
-		esc.client.Search.WithQuery("sender%"+address+"+receiver%"+address),
+		esc.client.Search.WithQuery(query),
 		esc.client.Search.WithSort("timestamp:desc"),
 	)
 	if err != nil {

--- a/process/database/queries.go
+++ b/process/database/queries.go
@@ -17,32 +17,6 @@ func encodeQuery(query object) (bytes.Buffer, error) {
 	return buff, nil
 }
 
-func txsByAddrQuery(addr string) object {
-	return object{
-		"query": object{
-			"bool": object{
-				"should": []interface{}{
-					object{
-						"match": object{
-							"sender": addr,
-						},
-					},
-					object{
-						"match": object{
-							"receiver": addr,
-						},
-					},
-				},
-			},
-		},
-		"sort": object{
-			"timestamp": object{
-				"order": "desc",
-			},
-		},
-	}
-}
-
 func blockByNonceAndShardIDQuery(nonce uint64, shardID uint32) object {
 	return object{
 		"query": object{

--- a/process/mock/elasticSearchConnectorMock.go
+++ b/process/mock/elasticSearchConnectorMock.go
@@ -1,0 +1,21 @@
+package mock
+
+import "github.com/ElrondNetwork/elrond-proxy-go/data"
+
+type ElasticSearchConnectorMock struct {
+}
+
+// GetTransactionsByAddress -
+func (escm *ElasticSearchConnectorMock) GetTransactionsByAddress(_ string) ([]data.DatabaseTransaction, error) {
+	return nil, nil
+}
+
+// GetAtlasBlockByShardIDAndNonce -
+func (escm *ElasticSearchConnectorMock) GetAtlasBlockByShardIDAndNonce(_ uint32, _ uint64) (data.AtlasBlock, error) {
+	return data.AtlasBlock{}, nil
+}
+
+// IsInterfaceNil -
+func (escm *ElasticSearchConnectorMock) IsInterfaceNil() bool {
+	return escm == nil
+}


### PR DESCRIPTION

BUG : when this api route `/address/:addr/transactions` is used with 2 different addresses in a short time interval the api returns the same result.