### PR TITLE
added total /network/total-staked api route

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ For more details, go to [docs.elrond.com](https://docs.elrond.com/sdk-and-tools/
 - `/v1.0/network/status/:shard`    (GET) --> returns the status metrics from an observer in the given shard
 - `/v1.0/network/config`           (GET) --> returns the configuration of the network from any observer
 - `/v1.0/network/economics`        (GET) --> returns the economics data metric from the last epoch
+- `/v1.0/network/total-staked`     (GET) --> returns the total staked value from the validators contract
 
 ### node
 

--- a/api/groups/baseNetworkGroup.go
+++ b/api/groups/baseNetworkGroup.go
@@ -30,6 +30,7 @@ func NewNetworkGroup(facadeHandler data.FacadeHandler) (*networkGroup, error) {
 		"/status/:shard": {Handler: ng.getNetworkStatusData, Method: http.MethodGet},
 		"/config":        {Handler: ng.getNetworkConfigData, Method: http.MethodGet},
 		"/economics":     {Handler: ng.getEconomicsData, Method: http.MethodGet},
+		"/total-staked":  {Handler: ng.getTotalStaked, Method: http.MethodGet},
 	}
 	ng.baseGroup.endpoints = baseRoutesHandlers
 
@@ -73,4 +74,15 @@ func (group *networkGroup) getEconomicsData(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, economicsData)
+}
+
+// getTotalStakedValue will expose the total staked value from an observer (if any available) in json format
+func (group *networkGroup) getTotalStaked(c *gin.Context) {
+	totalStakedData, err := group.facade.GetTotalStaked()
+	if err != nil {
+		shared.RespondWith(c, http.StatusInternalServerError, nil, err.Error(), data.ReturnCodeInternalError)
+		return
+	}
+
+	c.JSON(http.StatusOK, totalStakedData)
 }

--- a/api/groups/baseNetworkGroup_test.go
+++ b/api/groups/baseNetworkGroup_test.go
@@ -169,7 +169,7 @@ func TestGetNetworkConfigData_OkRequestShouldWork(t *testing.T) {
 	assert.Equal(t, value, res)
 }
 
-func TestGeTotalStaked_OkRequestShouldWork(t *testing.T) {
+func TestGetTotalStaked_OkRequestShouldWork(t *testing.T) {
 	t.Parallel()
 
 	key := "totalStakedValue"

--- a/api/groups/baseNetworkGroup_test.go
+++ b/api/groups/baseNetworkGroup_test.go
@@ -169,6 +169,62 @@ func TestGetNetworkConfigData_OkRequestShouldWork(t *testing.T) {
 	assert.Equal(t, value, res)
 }
 
+func TestGeTotalStaked_OkRequestShouldWork(t *testing.T) {
+	t.Parallel()
+
+	key := "totalStakedValue"
+	value := "2500000000000"
+	facade := &mock.Facade{
+		GetTotalStakedCalled: func() (*data.GenericAPIResponse, error) {
+			return &data.GenericAPIResponse{
+				Data: map[string]interface{}{
+					key: value,
+				},
+				Error: "",
+			}, nil
+		},
+	}
+	networkGroup, err := groups.NewNetworkGroup(facade)
+	require.NoError(t, err)
+	ws := startProxyServer(networkGroup, networkPath)
+
+	req, _ := http.NewRequest("GET", "/network/total-staked", nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+	assert.Equal(t, http.StatusOK, resp.Code)
+
+	var result metricsResponse
+	loadResponse(resp.Body, &result)
+
+	res, ok := result.Data[key]
+	assert.True(t, ok)
+	assert.Equal(t, value, res)
+}
+
+func TestGetTotalStaked_FacadeErrShouldErr(t *testing.T) {
+	t.Parallel()
+
+	expectedErr := errors.New("expected error")
+	facade := &mock.Facade{
+		GetTotalStakedCalled: func() (*data.GenericAPIResponse, error) {
+			return nil, expectedErr
+		},
+	}
+	networkGroup, err := groups.NewNetworkGroup(facade)
+	require.NoError(t, err)
+	ws := startProxyServer(networkGroup, networkPath)
+
+	req, _ := http.NewRequest("GET", "/network/total-staked", nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+	assert.Equal(t, http.StatusInternalServerError, resp.Code)
+
+	var result metricsResponse
+	loadResponse(resp.Body, &result)
+
+	assert.Equal(t, expectedErr.Error(), result.Error)
+}
+
 func TestGetEconomicsData_ShouldErr(t *testing.T) {
 	t.Parallel()
 

--- a/api/groups/interface.go
+++ b/api/groups/interface.go
@@ -39,6 +39,7 @@ type NetworkFacadeHandler interface {
 	GetNetworkStatusMetrics(shardID uint32) (*data.GenericAPIResponse, error)
 	GetNetworkConfigMetrics() (*data.GenericAPIResponse, error)
 	GetEconomicsDataMetrics() (*data.GenericAPIResponse, error)
+	GetTotalStaked() (*data.GenericAPIResponse, error)
 }
 
 // NodeFacadeHandler interface defines methods that can be used from facade context variable

--- a/api/mock/facade.go
+++ b/api/mock/facade.go
@@ -36,6 +36,7 @@ type Facade struct {
 	GetBlockByNonceCalled                       func(shardID uint32, nonce uint64, withTxs bool) (*data.BlockApiResponse, error)
 	GetHyperBlockByHashCalled                   func(hash string) (*data.HyperblockApiResponse, error)
 	GetHyperBlockByNonceCalled                  func(nonce uint64) (*data.HyperblockApiResponse, error)
+	GetTotalStakedCalled                        func() (*data.GenericAPIResponse, error)
 }
 
 // IsFaucetEnabled -
@@ -195,6 +196,15 @@ func (f *Facade) GetHyperBlockByHash(hash string) (*data.HyperblockApiResponse, 
 // GetHyperBlockByNonce -
 func (f *Facade) GetHyperBlockByNonce(nonce uint64) (*data.HyperblockApiResponse, error) {
 	return f.GetHyperBlockByNonceCalled(nonce)
+}
+
+// GetTotalStaked -
+func (f *Facade) GetTotalStaked() (*data.GenericAPIResponse, error) {
+	if f.GetTotalStakedCalled != nil {
+		return f.GetTotalStakedCalled()
+	}
+
+	return nil, nil
 }
 
 // WrongFacade is a struct that can be used as a wrong implementation of the node router handler

--- a/facade/baseFacade.go
+++ b/facade/baseFacade.go
@@ -242,6 +242,11 @@ func (epf *ElrondProxyFacade) GetNetworkStatusMetrics(shardID uint32) (*data.Gen
 	return epf.nodeStatusProc.GetNetworkStatusMetrics(shardID)
 }
 
+// GetTotalStaked retrieves the total staked value
+func (epf *ElrondProxyFacade) GetTotalStaked() (*data.GenericAPIResponse, error) {
+	return epf.nodeStatusProc.GetTotalStaked()
+}
+
 // GetNetworkStatusMetrics retrieves the node's network metrics for a given shard
 func (epf *ElrondProxyFacade) GetEconomicsDataMetrics() (*data.GenericAPIResponse, error) {
 	return epf.nodeStatusProc.GetEconomicsDataMetrics()

--- a/facade/interface.go
+++ b/facade/interface.go
@@ -47,6 +47,7 @@ type ValidatorStatisticsProcessor interface {
 
 // NodeStatusProcessor defines what a node status processor should do
 type NodeStatusProcessor interface {
+	GetTotalStaked() (*data.GenericAPIResponse, error)
 	GetNetworkConfigMetrics() (*data.GenericAPIResponse, error)
 	GetNetworkStatusMetrics(shardID uint32) (*data.GenericAPIResponse, error)
 	GetEconomicsDataMetrics() (*data.GenericAPIResponse, error)

--- a/facade/mock/nodeStatusProcessorStub.go
+++ b/facade/mock/nodeStatusProcessorStub.go
@@ -8,6 +8,7 @@ type NodeStatusProcessorStub struct {
 	GetNetworkMetricsCalled       func(shardID uint32) (*data.GenericAPIResponse, error)
 	GetLatestBlockNonceCalled     func() (uint64, error)
 	GetEconomicsDataMetricsCalled func() (*data.GenericAPIResponse, error)
+	GetTotalStakedCalled          func() (*data.GenericAPIResponse, error)
 }
 
 // GetNetworkConfigMetrics --
@@ -28,4 +29,8 @@ func (nsps *NodeStatusProcessorStub) GetEconomicsDataMetrics() (*data.GenericAPI
 // GetLatestBlockNonce -
 func (nsps *NodeStatusProcessorStub) GetLatestFullySynchronizedHyperblockNonce() (uint64, error) {
 	return nsps.GetLatestBlockNonceCalled()
+}
+
+func (nsps *NodeStatusProcessorStub) GetTotalStaked() (*data.GenericAPIResponse, error) {
+	return nsps.GetTotalStakedCalled()
 }

--- a/process/nodeStatusProcessor.go
+++ b/process/nodeStatusProcessor.go
@@ -66,6 +66,7 @@ func (nsp *NodeStatusProcessor) GetNetworkStatusMetrics(shardID uint32) (*data.G
 	return nil, ErrSendingRequest
 }
 
+// GetTotalStaked will simply forward the total staked value from a metachain observer
 func (nsp *NodeStatusProcessor) GetTotalStaked() (*data.GenericAPIResponse, error) {
 	observers, err := nsp.proc.GetObservers(core.MetachainShardId)
 	if err != nil {

--- a/process/nodeStatusProcessor.go
+++ b/process/nodeStatusProcessor.go
@@ -23,6 +23,9 @@ const EconomicsDataPath = "/network/economics"
 // NetworkConfigPath represents the path where an observer exposes his node status metrics
 const NodeStatusPath = "/node/status"
 
+// TotalStakedPath represents the path where an observer exposes the total staked value from validators contract
+const TotalStakedPath = "/network/total-staked"
+
 // NodeStatusProcessor handles the action needed for fetching data related to status metrics from nodes
 type NodeStatusProcessor struct {
 	proc Processor
@@ -57,6 +60,29 @@ func (nsp *NodeStatusProcessor) GetNetworkStatusMetrics(shardID uint32) (*data.G
 
 		log.Info("network metrics request", "shard id", observer.ShardId, "observer", observer.Address)
 		return responseNetworkMetrics, nil
+
+	}
+
+	return nil, ErrSendingRequest
+}
+
+func (nsp *NodeStatusProcessor) GetTotalStaked() (*data.GenericAPIResponse, error) {
+	observers, err := nsp.proc.GetObservers(core.MetachainShardId)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, observer := range observers {
+		var responseTotalStaked *data.GenericAPIResponse
+
+		_, err := nsp.proc.CallGetRestEndPoint(observer.Address, TotalStakedPath, &responseTotalStaked)
+		if err != nil {
+			log.Error("total staked request", "observer", observer.Address, "error", err.Error())
+			continue
+		}
+
+		log.Info("total staked request", "shard id", observer.ShardId, "observer", observer.Address)
+		return responseTotalStaked, nil
 
 	}
 

--- a/regressionTests/testjs/index.html
+++ b/regressionTests/testjs/index.html
@@ -150,6 +150,12 @@
             <button type="button" id="LoadNetworkStatus" class="btn btn-primary btn-sm">Test</button>
             <div id="LoadNetworkStatusOutput"></div>
         </div>
+        <div class="card-body">
+            <h5 class="card-title">/network/total-staked</h5>
+            <p class="card-text">Gets the network status for a given shard.</p>
+            <button type="button" id="LoadNetworkTotalStaked" class="btn btn-primary btn-sm">Test</button>
+            <div id="LoadNetworkTotalStakedOutput"></div>
+        </div>
     </div>
 
     <div class="card">

--- a/regressionTests/testjs/src/groups/networkGroup.ts
+++ b/regressionTests/testjs/src/groups/networkGroup.ts
@@ -20,4 +20,9 @@ export class NetworkGroup {
         let v1_0result = await this.v1_0Handler.handleNetworkStatus();
         return new Array<TestSuite>(v1_0result);
     }
+
+    async handlerNetworkTotalStaked(): Promise<Array<TestSuite>> {
+        let v1_0result = await this.v1_0Handler.handleNetworkTotalStaked();
+        return new Array<TestSuite>(v1_0result);
+    }
 }

--- a/regressionTests/testjs/src/handlers/v1.0/networkV1_0Handler.ts
+++ b/regressionTests/testjs/src/handlers/v1.0/networkV1_0Handler.ts
@@ -39,4 +39,18 @@ export class NetworkV1_0Handler {
             return TestSuite.withException("v1.0", error);
         }
     }
+
+    async handleNetworkTotalStaked(): Promise<TestSuite> {
+        let testPhases = new Array<TestPhase>();
+
+        let url = this.commonHandler.proxyURL + "/network/total-staked";
+        try {
+            let response = await this.commonHandler.httpRequestHandler.doGetRequest(url)
+            testPhases.push(this.commonHandler.runBasicTestPhaseOk(response, 200))
+
+            return new TestSuite("v1.0", testPhases, TestStatus.SUCCESSFUL, response)
+        } catch (error) {
+            return TestSuite.withException("v1.0", error);
+        }
+    }
 }

--- a/regressionTests/testjs/src/index.ts
+++ b/regressionTests/testjs/src/index.ts
@@ -145,6 +145,15 @@ $(async function () {
         }
     });
 
+    $("#LoadNetworkTotalStaked").click(async function (){
+        try {
+            let response = await networkGroup.handlerNetworkTotalStaked();
+            displayTestsSuites("LoadNetworkTotalStakedOutput", response);
+        } catch (error) {
+            onError(error);
+        }
+    })
+
 
     // -- Node group
 

--- a/regressionTests/testjs/src/index.ts
+++ b/regressionTests/testjs/src/index.ts
@@ -272,4 +272,5 @@ async function runAllTests() {
     $("#LoadVmValuesQuery").click();
     $("#LoadVmValuesInt").click();
     $("#LoadVmValuesString").click();
+    $("#LoadNetworkTotalStaked").click();
 }

--- a/testing/testHttpServer.go
+++ b/testing/testHttpServer.go
@@ -107,6 +107,11 @@ func (ths *TestHttpServer) processRequest(rw http.ResponseWriter, req *http.Requ
 		return
 	}
 
+	if strings.Contains(req.URL.Path, "network/total-staked") {
+		ths.processRequestGetTotalStaked(rw, req)
+		return
+	}
+
 	if strings.Contains(req.URL.Path, "/cost") {
 		ths.processRequestGetTxCost(rw, req)
 		return
@@ -229,7 +234,7 @@ func (ths *TestHttpServer) processRequestValidatorStatistics(rw http.ResponseWri
 }
 
 func (ths *TestHttpServer) processRequestGetNetworkMetrics(rw http.ResponseWriter, _ *http.Request) {
-	responsStatus := map[string]interface{}{
+	responseStatus := map[string]interface{}{
 		"erd_nonce":                          90,
 		"erd_current_round":                  120,
 		"erd_epoch_number":                   4,
@@ -237,14 +242,24 @@ func (ths *TestHttpServer) processRequestGetNetworkMetrics(rw http.ResponseWrite
 		"erd_rounds_passed_in_current_epoch": 30,
 		"erd_rounds_per_epoch":               30,
 	}
-	resp := data.GenericAPIResponse{Data: responsStatus, Code: data.ReturnCodeSuccess}
+	resp := data.GenericAPIResponse{Data: responseStatus, Code: data.ReturnCodeSuccess}
+	responseBuff, _ := json.Marshal(&resp)
+	_, err := rw.Write(responseBuff)
+	log.LogIfError(err)
+}
+
+func (ths *TestHttpServer) processRequestGetTotalStaked(rw http.ResponseWriter, _ *http.Request) {
+	responseStatus := map[string]interface{}{
+		"totalStakedValue": "250000000000000",
+	}
+	resp := data.GenericAPIResponse{Data: responseStatus, Code: data.ReturnCodeSuccess}
 	responseBuff, _ := json.Marshal(&resp)
 	_, err := rw.Write(responseBuff)
 	log.LogIfError(err)
 }
 
 func (ths *TestHttpServer) processRequestGetEconomicsMetrics(rw http.ResponseWriter, _ *http.Request) {
-	responsStatus := map[string]interface{}{
+	responseStatus := map[string]interface{}{
 		"erd_dev_rewards":              "0",
 		"erd_inflation":                "120",
 		"erd_epoch_number":             4,
@@ -259,7 +274,7 @@ func (ths *TestHttpServer) processRequestGetEconomicsMetrics(rw http.ResponseWri
 		Error string      `json:"error"`
 		Code  string      `json:"code"`
 	}{
-		Data: metricsResp{Metrics: responsStatus},
+		Data: metricsResp{Metrics: responseStatus},
 		Code: string(data.ReturnCodeSuccess),
 	}
 


### PR DESCRIPTION
Added /`network/total-staked` api route
This api route returns the total staked value from the validators system smart contract