### PR TITLE
added response logger middleware

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -84,7 +84,6 @@ func registerRoutes(
 	if apiLoggingConfig.LoggingEnabled {
 		responseLoggerMiddleware := middleware.NewResponseLoggerMiddleware(time.Duration(apiLoggingConfig.ThresholdInMicroSeconds) * time.Microsecond)
 		ws.Use(responseLoggerMiddleware.MiddlewareHandlerFunc())
-		log.Error("testtt")
 	}
 
 	for version, versionData := range versionsMap {

--- a/api/middleware/responseLogger.go
+++ b/api/middleware/responseLogger.go
@@ -1,0 +1,127 @@
+package middleware
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"time"
+	"unicode"
+
+	logger "github.com/ElrondNetwork/elrond-go-logger"
+	"github.com/gin-gonic/gin"
+)
+
+var log = logger.GetOrCreate("api/middleware")
+
+const prefixDurationTooLong = "[too long]"
+const prefixBadRequest = "[bad request]"
+const prefixInternalError = "[internal error]"
+
+type responseLoggerMiddleware struct {
+	thresholdDurationForLoggingRequest time.Duration
+	printRequestFunc                   func(title string, path string, duration time.Duration, status int, request string, response string)
+}
+
+// NewResponseLoggerMiddleware returns a new instance of responseLoggerMiddleware
+func NewResponseLoggerMiddleware(thresholdDurationForLoggingRequest time.Duration) *responseLoggerMiddleware {
+	rlm := &responseLoggerMiddleware{
+		thresholdDurationForLoggingRequest: thresholdDurationForLoggingRequest,
+	}
+
+	rlm.printRequestFunc = rlm.printRequest
+
+	return rlm
+}
+
+// MonitoringMiddleware logs detail about a request if it is not successful or it's duration is higher than a threshold
+func (rlm *responseLoggerMiddleware) MiddlewareHandlerFunc() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		t := time.Now()
+
+		bw := &bodyWriter{body: bytes.NewBufferString(""), ResponseWriter: c.Writer}
+		c.Writer = bw
+
+		c.Next()
+
+		latency := time.Since(t)
+		status := c.Writer.Status()
+
+		shouldLogRequest := latency > rlm.thresholdDurationForLoggingRequest || c.Writer.Status() != http.StatusOK
+		if shouldLogRequest {
+			responseBodyString := removeWhitespacesFromString(bw.body.String())
+			rlm.logRequestAndResponse(c, latency, status, responseBodyString)
+		}
+	}
+}
+
+// IsInterfaceNil returns true if there is no value under the interface
+func (rlm *responseLoggerMiddleware) IsInterfaceNil() bool {
+	return rlm == nil
+}
+
+func (rlm *responseLoggerMiddleware) logRequestAndResponse(c *gin.Context, duration time.Duration, status int, response string) {
+	request := "n/a"
+
+	if c.Request.Body != nil {
+		reqBody := c.Request.Body
+		reqBodyBytes, err := ioutil.ReadAll(reqBody)
+		if err != nil {
+			log.Error(err.Error())
+			return
+		}
+
+		if len(reqBodyBytes) > 0 {
+			request = removeWhitespacesFromString(string(reqBodyBytes))
+		}
+	}
+
+	title := rlm.computeLogTitle(status)
+
+	rlm.printRequestFunc(title, c.Request.RequestURI, duration, status, request, response)
+}
+
+func (rlm *responseLoggerMiddleware) computeLogTitle(status int) string {
+	logPrefix := prefixDurationTooLong
+	if status == http.StatusBadRequest {
+		logPrefix = prefixBadRequest
+	} else if status == http.StatusInternalServerError {
+		logPrefix = prefixInternalError
+	} else if status != http.StatusOK {
+		logPrefix = fmt.Sprintf("http code %d", status)
+	}
+
+	return fmt.Sprintf("%s api request", logPrefix)
+}
+
+func (rlm *responseLoggerMiddleware) printRequest(title string, path string, duration time.Duration, status int, request string, response string) {
+	log.Warn(title,
+		"path", path,
+		"duration", duration,
+		"status", status,
+		"request", request,
+		"response", response,
+	)
+}
+
+func removeWhitespacesFromString(str string) string {
+	var b strings.Builder
+	b.Grow(len(str))
+	for _, ch := range str {
+		if !unicode.IsSpace(ch) {
+			b.WriteRune(ch)
+		}
+	}
+	return b.String()
+}
+
+type bodyWriter struct {
+	gin.ResponseWriter
+	body *bytes.Buffer
+}
+
+func (w bodyWriter) Write(b []byte) (int, error) {
+	w.body.Write(b)
+	return w.ResponseWriter.Write(b)
+}

--- a/api/middleware/responseLogger.go
+++ b/api/middleware/responseLogger.go
@@ -19,6 +19,8 @@ const prefixDurationTooLong = "[too long]"
 const prefixBadRequest = "[bad request]"
 const prefixInternalError = "[internal error]"
 
+// TODO: remove this file and use the same middleware from elrond-go after it is merged
+
 type responseLoggerMiddleware struct {
 	thresholdDurationForLoggingRequest time.Duration
 	printRequestFunc                   func(title string, path string, duration time.Duration, status int, request string, response string)

--- a/api/middleware/responseLogger_test.go
+++ b/api/middleware/responseLogger_test.go
@@ -1,0 +1,153 @@
+package middleware
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ElrondNetwork/elrond-go/core/check"
+	"github.com/ElrondNetwork/elrond-proxy-go/api/groups"
+	"github.com/ElrondNetwork/elrond-proxy-go/api/mock"
+	"github.com/ElrondNetwork/elrond-proxy-go/data"
+	"github.com/gin-contrib/cors"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+func startApiServerResponseLogger(handler groups.AccountsFacadeHandler, respLogMiddleware *responseLoggerMiddleware) *gin.Engine {
+	ws := gin.New()
+	ws.Use(cors.Default())
+	ws.Use(respLogMiddleware.MiddlewareHandlerFunc())
+	accGr, _ := groups.NewAccountsGroup(handler)
+
+	group := ws.Group("/address")
+	accGr.RegisterRoutes(group, data.ApiRoutesConfig{}, func(_ *gin.Context) {})
+	return ws
+}
+
+type responseLogFields struct {
+	title    string
+	path     string
+	request  string
+	duration time.Duration
+	status   int
+	response string
+}
+
+func TestNewResponseLoggerMiddleware(t *testing.T) {
+	t.Parallel()
+
+	rlm := NewResponseLoggerMiddleware(10)
+
+	assert.False(t, check.IfNil(rlm))
+}
+
+func TestResponseLoggerMiddleware_DurationExceedsTimeout(t *testing.T) {
+	t.Parallel()
+
+	thresholdDuration := 10 * time.Millisecond
+	addr := "testAddress"
+	facade := mock.Facade{
+		GetAccountHandler: func(s string) (i *data.Account, e error) {
+			time.Sleep(thresholdDuration + 1*time.Millisecond)
+			return &data.Account{Balance: "37777"}, nil
+		},
+	}
+
+	rlf := responseLogFields{}
+	printHandler := func(title string, path string, duration time.Duration, status int, request string, response string) {
+		rlf.title = title
+		rlf.path = path
+		rlf.duration = duration
+		rlf.status = status
+		rlf.response = response
+		rlf.request = request
+	}
+
+	rlm := NewResponseLoggerMiddleware(thresholdDuration)
+	rlm.printRequestFunc = printHandler
+
+	ws := startApiServerResponseLogger(&facade, rlm)
+
+	req, _ := http.NewRequest("GET", fmt.Sprintf("/address/%s/balance", addr), nil)
+	req.RemoteAddr = "bad address"
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	assert.Equal(t, http.StatusOK, resp.Code)
+	assert.True(t, strings.Contains(rlf.title, prefixDurationTooLong))
+	assert.True(t, rlf.duration > thresholdDuration)
+	assert.Equal(t, http.StatusOK, rlf.status)
+	assert.True(t, strings.Contains(rlf.response, "37777"))
+}
+
+func TestResponseLoggerMiddleware_InternalError(t *testing.T) {
+	t.Parallel()
+
+	expectedErr := errors.New("internal err")
+	thresholdDuration := 10000 * time.Millisecond
+	facade := mock.Facade{
+		GetAccountHandler: func(_ string) (*data.Account, error) {
+			return nil, expectedErr
+		},
+	}
+
+	rlf := responseLogFields{}
+	printHandler := func(title string, path string, duration time.Duration, status int, request string, response string) {
+		rlf.title = title
+		rlf.path = path
+		rlf.duration = duration
+		rlf.status = status
+		rlf.response = response
+		rlf.request = request
+	}
+
+	rlm := NewResponseLoggerMiddleware(thresholdDuration)
+	rlm.printRequestFunc = printHandler
+
+	ws := startApiServerResponseLogger(&facade, rlm)
+
+	req, _ := http.NewRequest("GET", "/address/addr/balance", nil)
+	req.RemoteAddr = "bad address"
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	assert.Equal(t, http.StatusInternalServerError, resp.Code)
+	assert.True(t, strings.Contains(rlf.title, prefixInternalError))
+	assert.True(t, rlf.duration < thresholdDuration)
+	assert.Equal(t, http.StatusInternalServerError, rlf.status)
+	assert.True(t, strings.Contains(rlf.response, removeWhitespacesFromString(expectedErr.Error())))
+}
+
+func TestResponseLoggerMiddleware_ShouldNotCallHandler(t *testing.T) {
+	t.Parallel()
+
+	thresholdDuration := 10000 * time.Millisecond
+	facade := mock.Facade{
+		GetAccountHandler: func(s string) (i *data.Account, e error) {
+			return &data.Account{Balance: "5555"}, nil
+		},
+	}
+
+	handlerWasCalled := false
+	printHandler := func(title string, path string, duration time.Duration, status int, request string, response string) {
+		handlerWasCalled = true
+	}
+
+	rlm := NewResponseLoggerMiddleware(thresholdDuration)
+	rlm.printRequestFunc = printHandler
+
+	ws := startApiServerResponseLogger(&facade, rlm)
+
+	req, _ := http.NewRequest("GET", "/address/addr/balance", nil)
+	req.RemoteAddr = "bad address"
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	assert.Equal(t, http.StatusOK, resp.Code)
+	assert.False(t, handlerWasCalled)
+}

--- a/cmd/proxy/config/config.toml
+++ b/cmd/proxy/config/config.toml
@@ -38,6 +38,16 @@
 [Hasher]
    Type = "blake2b"
 
+# ApiLogging holds settings related to api requests logging
+[ApiLogging]
+   # LoggingEnabled - if this flag is set to true, then if a requests exceeds a threshold or it is unsuccessful, then
+   # a log will be printed
+   LoggingEnabled = false
+
+   # ThresholdInMicroSeconds represents the maximum duration to consider a request as normal. Above this, if the LoggingEnabled
+   # flag is set to true, then a log will be printed
+   ThresholdInMicroSeconds = 100
+
 # List of Observers. If you want to define a metachain observer (needed for validator statistics route) use
 # shard id 4294967295
 [[Observers]]

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -583,7 +583,7 @@ func startWebServer(
 		}
 		httpServer, err = rosetta.CreateServer(facades["v1.0"].Facade, generalConfig, port)
 	} else {
-		httpServer, err = api.CreateServer(versionsRegistry, port, credentialsConfig)
+		httpServer, err = api.CreateServer(versionsRegistry, port, generalConfig.ApiLogging, credentialsConfig)
 	}
 	if err != nil {
 		return nil, err

--- a/config/config.go
+++ b/config/config.go
@@ -22,8 +22,15 @@ type Config struct {
 	AddressPubkeyConverter config.PubkeyConfig
 	Marshalizer            config.TypeConfig
 	Hasher                 config.TypeConfig
+	ApiLogging             ApiLoggingConfig
 	Observers              []*data.NodeData
 	FullHistoryNodes       []*data.NodeData
+}
+
+// ApiLoggingConfig holds the configuration related to API requests logging
+type ApiLoggingConfig struct {
+	LoggingEnabled          bool
+	ThresholdInMicroSeconds int
 }
 
 // CredentialsConfig holds the credential pairs


### PR DESCRIPTION
Added a response logger middleware.
The same middleware should be used from elrond-go, but the dependency in the `go.mon` cannot be updated based on a commit hash, so we wait until that Pull Request is merged and/or included in a release.