### PR TITLE
EN-5584: endpoint for getting key-value pairs for addresses

### DIFF
--- a/api/errors/errors.go
+++ b/api/errors/errors.go
@@ -11,14 +11,14 @@ var ErrInvalidAppContext = errors.New("invalid app context")
 // ErrGetValueForKey signals an error in getting the value of a key for an account
 var ErrGetValueForKey = errors.New("get value for key error")
 
+// ErrGetKeyValuePairs signals an error in getting the key-value pairs for a given address
+var ErrGetKeyValuePairs = errors.New("get key value pairs error")
+
 // ErrComputeShardForAddress signals an error in computing the shard ID for a given address
 var ErrComputeShardForAddress = errors.New("compute shard ID for address error")
 
 // ErrGetESDTTokenData signals an error in fetching an ESDT token data
 var ErrGetESDTTokenData = errors.New("cannot get ESDT token data")
-
-// ErrGetAllESDTTokens signals an error in fetching all ESDT tokens for an address
-var ErrGetAllESDTTokens = errors.New("cannot get all ESDT tokens")
 
 // ErrEmptyAddress signals that an empty address was provided
 var ErrEmptyAddress = errors.New("address is empty")

--- a/api/groups/baseAccountsGroup.go
+++ b/api/groups/baseAccountsGroup.go
@@ -34,6 +34,7 @@ func NewAccountsGroup(facadeHandler data.FacadeHandler) (*accountsGroup, error) 
 		"/:address/nonce":                 {Handler: ag.getNonce, Method: http.MethodGet},
 		"/:address/shard":                 {Handler: ag.getShard, Method: http.MethodGet},
 		"/:address/transactions":          {Handler: ag.getTransactions, Method: http.MethodGet},
+		"/:address/keys":                  {Handler: ag.getKeyValuePairs, Method: http.MethodGet},
 		"/:address/key/:key":              {Handler: ag.getValueForKey, Method: http.MethodGet},
 		"/:address/esdt":                  {Handler: ag.getESDTTokens, Method: http.MethodGet},
 		"/:address/esdt/:tokenIdentifier": {Handler: ag.getESDTTokenData, Method: http.MethodGet},
@@ -117,6 +118,29 @@ func (group *accountsGroup) getTransactions(c *gin.Context) {
 	}
 
 	shared.RespondWith(c, http.StatusOK, gin.H{"transactions": transactions}, "", data.ReturnCodeSuccess)
+}
+
+// getKeyValuePairs returns the key-value pairs for the address parameter
+func (group *accountsGroup) getKeyValuePairs(c *gin.Context) {
+	addr := c.Param("address")
+	if addr == "" {
+		shared.RespondWith(
+			c,
+			http.StatusBadRequest,
+			nil,
+			fmt.Sprintf("%v: %v", errors.ErrGetKeyValuePairs, errors.ErrEmptyAddress),
+			data.ReturnCodeRequestError,
+		)
+		return
+	}
+
+	keyValuePairs, err := group.facade.GetKeyValuePairs(addr)
+	if err != nil {
+		shared.RespondWith(c, http.StatusInternalServerError, nil, err.Error(), data.ReturnCodeInternalError)
+		return
+	}
+
+	c.JSON(http.StatusOK, keyValuePairs)
 }
 
 // getValueForKey returns the value for the given address and key

--- a/api/groups/baseAccountsGroup_test.go
+++ b/api/groups/baseAccountsGroup_test.go
@@ -434,3 +434,63 @@ func TestGetESDTTokenData_ReturnsSuccessfully(t *testing.T) {
 	assert.Equal(t, shardResponse.Data.TokenData, expectedTokenData)
 	assert.Empty(t, shardResponse.Error)
 }
+
+// ---- GetKeyValuePairs
+
+func TestGetKeyValuePairs_FailWhenFacadeErrors(t *testing.T) {
+	t.Parallel()
+
+	expectedErr := errors.New("internal err")
+	facade := &mock.Facade{
+		GetKeyValuePairsHandler: func(_ string) (*data.GenericAPIResponse, error) {
+			return nil, expectedErr
+		},
+	}
+	addressGroup, err := groups.NewAccountsGroup(facade)
+	require.NoError(t, err)
+	ws := startProxyServer(addressGroup, addressPath)
+
+	reqAddress := "test"
+	req, _ := http.NewRequest("GET", fmt.Sprintf("/address/%s/keys", reqAddress), nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	response := &data.GenericAPIResponse{}
+	loadResponse(resp.Body, &response)
+
+	assert.Equal(t, http.StatusInternalServerError, resp.Code)
+	assert.True(t, strings.Contains(response.Error, expectedErr.Error()))
+}
+
+func TestGetKeyValuePairs_ReturnsSuccessfully(t *testing.T) {
+	t.Parallel()
+
+	expectedResponse := &data.GenericAPIResponse{
+		Data: map[string]interface{}{"pairs": map[string]interface{}{
+			"key1": "value1",
+			"key2": "value2",
+		}},
+		Error: "",
+		Code:  data.ReturnCodeSuccess,
+	}
+	facade := &mock.Facade{
+		GetKeyValuePairsHandler: func(_ string) (*data.GenericAPIResponse, error) {
+			return expectedResponse, nil
+		},
+	}
+	addressGroup, err := groups.NewAccountsGroup(facade)
+	require.NoError(t, err)
+	ws := startProxyServer(addressGroup, addressPath)
+
+	reqAddress := "test"
+	req, _ := http.NewRequest("GET", fmt.Sprintf("/address/%s/keys", reqAddress), nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	actualResponse := &data.GenericAPIResponse{}
+	loadResponse(resp.Body, &actualResponse)
+
+	assert.Equal(t, http.StatusOK, resp.Code)
+	assert.Equal(t, expectedResponse, actualResponse)
+	assert.Empty(t, actualResponse.Error)
+}

--- a/api/groups/interface.go
+++ b/api/groups/interface.go
@@ -14,6 +14,7 @@ type AccountsFacadeHandler interface {
 	GetShardIDForAddress(address string) (uint32, error)
 	GetValueForKey(address string, key string) (string, error)
 	GetAllESDTTokens(address string) (*data.GenericAPIResponse, error)
+	GetKeyValuePairs(address string) (*data.GenericAPIResponse, error)
 	GetESDTTokenData(address string, key string) (*data.GenericAPIResponse, error)
 }
 

--- a/api/mock/facade.go
+++ b/api/mock/facade.go
@@ -14,6 +14,7 @@ type Facade struct {
 	GetAccountHandler                           func(address string) (*data.Account, error)
 	GetShardIDForAddressHandler                 func(address string) (uint32, error)
 	GetValueForKeyHandler                       func(address string, key string) (string, error)
+	GetKeyValuePairsHandler                     func(address string) (*data.GenericAPIResponse, error)
 	GetESDTTokenDataCalled                      func(address string, key string) (*data.GenericAPIResponse, error)
 	GetAllESDTTokensCalled                      func(address string) (*data.GenericAPIResponse, error)
 	GetTransactionsHandler                      func(address string) ([]data.DatabaseTransaction, error)
@@ -103,6 +104,11 @@ func (f *Facade) ValidatorStatistics() (map[string]*data.ValidatorApiResponse, e
 // GetAccount -
 func (f *Facade) GetAccount(address string) (*data.Account, error) {
 	return f.GetAccountHandler(address)
+}
+
+// GetKeyValuePairs -
+func (f *Facade) GetKeyValuePairs(address string) (*data.GenericAPIResponse, error) {
+	return f.GetKeyValuePairsHandler(address)
 }
 
 // GetValueForKey -

--- a/cmd/proxy/config/apiConfig/v1_0.toml
+++ b/cmd/proxy/config/apiConfig/v1_0.toml
@@ -18,6 +18,7 @@ Routes = [
     { Name = "/:address/balance", Open = true, Secured = false },
     { Name = "/:address/nonce", Open = true, Secured = false },
     { Name = "/:address/username", Open = true, Secured = false },
+    { Name = "/:address/keys", Open = true, Secured = false },
     { Name = "/:address/key/:key", Open = true, Secured = false },
     { Name = "/:address/esdt", Open = true, Secured = false },
     { Name = "/:address/esdt/:tokenIdentifier", Open = true, Secured = false },

--- a/cmd/proxy/config/apiConfig/v_next.toml
+++ b/cmd/proxy/config/apiConfig/v_next.toml
@@ -18,6 +18,7 @@ Routes = [
     { Name = "/:address/balance", Open = true, Secured = false },
     { Name = "/:address/username", Open = true, Secured = false },
     { Name = "/:address/new-endpoint", Open = true, Secured = false },
+    { Name = "/:address/keys", Open = true, Secured = false },
     { Name = "/:address/key/:key", Open = true, Secured = false },
     { Name = "/:address/esdt", Open = true, Secured = false },
     { Name = "/:address/esdt/:tokenIdentifier", Open = true, Secured = false },

--- a/facade/baseFacade.go
+++ b/facade/baseFacade.go
@@ -97,6 +97,11 @@ func (epf *ElrondProxyFacade) GetAccount(address string) (*data.Account, error) 
 	return epf.accountProc.GetAccount(address)
 }
 
+// GetKeyValuePairs returns the key-value pairs for the given address
+func (epf *ElrondProxyFacade) GetKeyValuePairs(address string) (*data.GenericAPIResponse, error) {
+	return epf.accountProc.GetKeyValuePairs(address)
+}
+
 // GetValueForKey returns the value for the given address and key
 func (epf *ElrondProxyFacade) GetValueForKey(address string, key string) (string, error) {
 	return epf.accountProc.GetValueForKey(address, key)

--- a/facade/interface.go
+++ b/facade/interface.go
@@ -21,6 +21,7 @@ type AccountProcessor interface {
 	GetValueForKey(address string, key string) (string, error)
 	GetTransactions(address string) ([]data.DatabaseTransaction, error)
 	GetAllESDTTokens(address string) (*data.GenericAPIResponse, error)
+	GetKeyValuePairs(address string) (*data.GenericAPIResponse, error)
 	GetESDTTokenData(address string, key string) (*data.GenericAPIResponse, error)
 }
 

--- a/facade/mock/accountProccessorStub.go
+++ b/facade/mock/accountProccessorStub.go
@@ -13,6 +13,12 @@ type AccountProcessorStub struct {
 	ValidatorStatisticsCalled  func() (map[string]*data.ValidatorApiResponse, error)
 	GetAllESDTTokensCalled     func(address string) (*data.GenericAPIResponse, error)
 	GetESDTTokenDataCalled     func(address string, key string) (*data.GenericAPIResponse, error)
+	GetKeyValuePairsCalled     func(address string) (*data.GenericAPIResponse, error)
+}
+
+// GetKeyValuePairs -
+func (aps *AccountProcessorStub) GetKeyValuePairs(address string) (*data.GenericAPIResponse, error) {
+	return aps.GetKeyValuePairsCalled(address)
 }
 
 // GetAllESDTTokens -

--- a/process/accountProcessor.go
+++ b/process/accountProcessor.go
@@ -144,7 +144,7 @@ func (ap *AccountProcessor) GetAllESDTTokens(address string) (*data.GenericAPIRe
 		apiPath := AddressPath + address + "/esdt"
 		respCode, err := ap.proc.CallGetRestEndPoint(observer.Address, apiPath, &apiResponse)
 		if err == nil || respCode == http.StatusBadRequest || respCode == http.StatusInternalServerError {
-			log.Info("account all ESDT tokens error",
+			log.Info("account all ESDT tokens",
 				"address", address,
 				"shard ID", observer.ShardId,
 				"observer", observer.Address,
@@ -157,6 +157,36 @@ func (ap *AccountProcessor) GetAllESDTTokens(address string) (*data.GenericAPIRe
 		}
 
 		log.Error("account get all ESDT tokens error", "observer", observer.Address, "address", address, "error", err.Error())
+	}
+
+	return nil, ErrSendingRequest
+}
+
+// GetKeyValuePairs returns all the key-value pairs for a given address
+func (ap *AccountProcessor) GetKeyValuePairs(address string) (*data.GenericAPIResponse, error) {
+	observers, err := ap.getObserversForAddress(address)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, observer := range observers {
+		apiResponse := data.GenericAPIResponse{}
+		apiPath := AddressPath + address + "/keys"
+		respCode, err := ap.proc.CallGetRestEndPoint(observer.Address, apiPath, &apiResponse)
+		if err == nil || respCode == http.StatusBadRequest || respCode == http.StatusInternalServerError {
+			log.Info("account get all key-value pairs",
+				"address", address,
+				"shard ID", observer.ShardId,
+				"observer", observer.Address,
+				"http code", respCode)
+			if apiResponse.Error != "" {
+				return nil, errors.New(apiResponse.Error)
+			}
+
+			return &apiResponse, nil
+		}
+
+		log.Error("account get all key-value pairs error", "observer", observer.Address, "address", address, "error", err.Error())
 	}
 
 	return nil, ErrSendingRequest


### PR DESCRIPTION
Implemented the `address/{address}/keys` endpoint that will return a map containing all keys and their values for an account. The value is represented in hexadecimal encoding.