### PR TITLE
query param /transaction/simulate

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ For more details, go to [docs.elrond.com](https://docs.elrond.com/sdk-and-tools/
 
 - `/v1.0/transaction/send`         (POST) --> receives a single transaction in JSON format and forwards it to an observer in the same shard as the sender's shard ID. Returns the transaction's hash if successful or the interceptor error otherwise.
 - `/v1.0/transaction/simulate`         (POST) --> same as /transaction/send but does not execute it. will output simulation results
+- `/v1.0/transaction/simulate?checkSignature=false`         (POST) --> same as /transaction/send but does not execute it, also the signature of the transaction will not be verified. will output simulation results
 - `/v1.0/transaction/send-multiple` (POST) --> receives a bulk of transactions in JSON format and will forward them to observers in the rights shards. Will return the number of transactions which were accepted by the interceptor and forwarded on the p2p topic.
 - `/v1.0/transaction/send-user-funds` (POST) --> receives a request containing `address`, `numOfTxs` and `value` and will select a random account from the PEM file in the same shard as the address received. Will return the transaction's hash if successful or the interceptor error otherwise.
 - `/v1.0/transaction/cost`         (POST) --> receives a single transaction in JSON format and returns it's cost

--- a/api/errors/errors.go
+++ b/api/errors/errors.go
@@ -44,6 +44,9 @@ var ErrValidation = errors.New("validation error")
 // ErrValidationQueryParameterWithResult signals that an invalid query parameter has been provided
 var ErrValidationQueryParameterWithResult = errors.New("invalid query parameter withResults")
 
+// ErrValidatorQueryParameterCheckSignature signals that an invalid query parameter has been provided
+var ErrValidatorQueryParameterCheckSignature = errors.New("invalid query parameter checkSignature")
+
 // ErrInvalidSignatureHex signals a wrong hex value was provided for the signature
 var ErrInvalidSignatureHex = errors.New("invalid signature, could not decode hex value")
 

--- a/api/groups/baseTransactionGroup_test.go
+++ b/api/groups/baseTransactionGroup_test.go
@@ -202,7 +202,7 @@ func TestSimulateTransaction_ErrorWhenFacadeSimulateTransactionError(t *testing.
 	errorString := "simulate transaction error"
 
 	facade := &mock.Facade{
-		SimulateTransactionHandler: func(tx *data.Transaction) (*data.GenericAPIResponse, error) {
+		SimulateTransactionHandler: func(tx *data.Transaction, _ bool) (*data.GenericAPIResponse, error) {
 			return nil, errors.New(errorString)
 		},
 	}
@@ -247,7 +247,7 @@ func TestSimulateTransaction_ReturnsSuccessfully(t *testing.T) {
 		Code: data.ReturnCodeSuccess,
 	}
 	facade := &mock.Facade{
-		SimulateTransactionHandler: func(tx *data.Transaction) (*data.GenericAPIResponse, error) {
+		SimulateTransactionHandler: func(tx *data.Transaction, _ bool) (*data.GenericAPIResponse, error) {
 			return &expectedResult, nil
 		},
 	}

--- a/api/groups/interface.go
+++ b/api/groups/interface.go
@@ -52,7 +52,7 @@ type NodeFacadeHandler interface {
 type TransactionFacadeHandler interface {
 	SendTransaction(tx *data.Transaction) (int, string, error)
 	SendMultipleTransactions(txs []*data.Transaction) (data.MultipleTransactionsResponseData, error)
-	SimulateTransaction(tx *data.Transaction) (*data.GenericAPIResponse, error)
+	SimulateTransaction(tx *data.Transaction, checkSignature bool) (*data.GenericAPIResponse, error)
 	IsFaucetEnabled() bool
 	SendUserFunds(receiver string, value *big.Int) error
 	TransactionCostRequest(tx *data.Transaction) (string, error)

--- a/api/mock/facade.go
+++ b/api/mock/facade.go
@@ -21,7 +21,7 @@ type Facade struct {
 	GetTransactionHandler                       func(txHash string, withResults bool) (*data.FullTransaction, error)
 	SendTransactionHandler                      func(tx *data.Transaction) (int, string, error)
 	SendMultipleTransactionsHandler             func(txs []*data.Transaction) (data.MultipleTransactionsResponseData, error)
-	SimulateTransactionHandler                  func(tx *data.Transaction) (*data.GenericAPIResponse, error)
+	SimulateTransactionHandler                  func(tx *data.Transaction, checkSignature bool) (*data.GenericAPIResponse, error)
 	SendUserFundsCalled                         func(receiver string, value *big.Int) error
 	ExecuteSCQueryHandler                       func(query *data.SCQuery) (*vm.VMOutputApi, error)
 	GetHeartbeatDataHandler                     func() (*data.HeartbeatResponse, error)
@@ -160,8 +160,8 @@ func (f *Facade) SendTransaction(tx *data.Transaction) (int, string, error) {
 }
 
 // SimulateTransaction -
-func (f *Facade) SimulateTransaction(tx *data.Transaction) (*data.GenericAPIResponse, error) {
-	return f.SimulateTransactionHandler(tx)
+func (f *Facade) SimulateTransaction(tx *data.Transaction, checkSignature bool) (*data.GenericAPIResponse, error) {
+	return f.SimulateTransactionHandler(tx, checkSignature)
 }
 
 // GetAddressConverter -

--- a/facade/baseFacade.go
+++ b/facade/baseFacade.go
@@ -138,8 +138,8 @@ func (epf *ElrondProxyFacade) SendMultipleTransactions(txs []*data.Transaction) 
 }
 
 // SimulateTransaction should send the transaction to the correct observer for simulation
-func (epf *ElrondProxyFacade) SimulateTransaction(tx *data.Transaction) (*data.GenericAPIResponse, error) {
-	return epf.txProc.SimulateTransaction(tx)
+func (epf *ElrondProxyFacade) SimulateTransaction(tx *data.Transaction, checkSignature bool) (*data.GenericAPIResponse, error) {
+	return epf.txProc.SimulateTransaction(tx, checkSignature)
 }
 
 // TransactionCostRequest should return how many gas units a transaction will cost

--- a/facade/baseFacade_test.go
+++ b/facade/baseFacade_test.go
@@ -261,7 +261,7 @@ func TestElrondProxyFacade_SimulateTransaction(t *testing.T) {
 		&mock.ActionsProcessorStub{},
 		&mock.AccountProcessorStub{},
 		&mock.TransactionProcessorStub{
-			SimulateTransactionCalled: func(tx *data.Transaction) (*data.GenericAPIResponse, error) {
+			SimulateTransactionCalled: func(tx *data.Transaction, checkSignature bool) (*data.GenericAPIResponse, error) {
 				wasCalled = true
 				return nil, nil
 			},
@@ -275,7 +275,7 @@ func TestElrondProxyFacade_SimulateTransaction(t *testing.T) {
 		publicKeyConverter,
 	)
 
-	_, _ = epf.SimulateTransaction(&data.Transaction{})
+	_, _ = epf.SimulateTransaction(&data.Transaction{}, false)
 
 	assert.True(t, wasCalled)
 }

--- a/facade/interface.go
+++ b/facade/interface.go
@@ -29,7 +29,7 @@ type AccountProcessor interface {
 type TransactionProcessor interface {
 	SendTransaction(tx *data.Transaction) (int, string, error)
 	SendMultipleTransactions(txs []*data.Transaction) (data.MultipleTransactionsResponseData, error)
-	SimulateTransaction(tx *data.Transaction) (*data.GenericAPIResponse, error)
+	SimulateTransaction(tx *data.Transaction, checkSignature bool) (*data.GenericAPIResponse, error)
 	TransactionCostRequest(tx *data.Transaction) (string, error)
 	GetTransactionStatus(txHash string, sender string) (string, error)
 	GetTransaction(txHash string, withEvents bool) (*data.FullTransaction, error)

--- a/facade/mock/transactionProcessorStub.go
+++ b/facade/mock/transactionProcessorStub.go
@@ -10,7 +10,7 @@ import (
 type TransactionProcessorStub struct {
 	SendTransactionCalled                      func(tx *data.Transaction) (int, string, error)
 	SendMultipleTransactionsCalled             func(txs []*data.Transaction) (data.MultipleTransactionsResponseData, error)
-	SimulateTransactionCalled                  func(tx *data.Transaction) (*data.GenericAPIResponse, error)
+	SimulateTransactionCalled                  func(tx *data.Transaction, checkSignature bool) (*data.GenericAPIResponse, error)
 	SendUserFundsCalled                        func(receiver string, value *big.Int) error
 	TransactionCostRequestHandler              func(tx *data.Transaction) (string, error)
 	GetTransactionStatusHandler                func(txHash string, sender string) (string, error)
@@ -20,8 +20,8 @@ type TransactionProcessorStub struct {
 }
 
 // SimulateTransaction -
-func (tps *TransactionProcessorStub) SimulateTransaction(tx *data.Transaction) (*data.GenericAPIResponse, error) {
-	return tps.SimulateTransactionCalled(tx)
+func (tps *TransactionProcessorStub) SimulateTransaction(tx *data.Transaction, checkSignature bool) (*data.GenericAPIResponse, error) {
+	return tps.SimulateTransactionCalled(tx, checkSignature)
 }
 
 // SendTransaction -

--- a/process/transactionProcessor.go
+++ b/process/transactionProcessor.go
@@ -34,7 +34,10 @@ const TransactionCostPath = "/transaction/cost"
 // UnknownStatusTx defines the response that should be received from an observer when transaction status is unknown
 const UnknownStatusTx = "unknown"
 
-const withResultsParam = "?withResults=true"
+const (
+	withResultsParam    = "?withResults=true"
+	checkSignatureFalse = "?checkSignature=false"
+)
 
 type requestType int
 
@@ -141,7 +144,7 @@ func (tp *TransactionProcessor) SendTransaction(tx *data.Transaction) (int, stri
 }
 
 // SimulateTransaction relays the post request by sending the request to the right observer and replies back the answer
-func (tp *TransactionProcessor) SimulateTransaction(tx *data.Transaction) (*data.GenericAPIResponse, error) {
+func (tp *TransactionProcessor) SimulateTransaction(tx *data.Transaction, checkSignature bool) (*data.GenericAPIResponse, error) {
 	err := tp.checkTransactionFields(tx)
 	if err != nil {
 		return nil, err
@@ -162,7 +165,7 @@ func (tp *TransactionProcessor) SimulateTransaction(tx *data.Transaction) (*data
 		return nil, err
 	}
 
-	response, err := tp.simulateTransaction(observers, tx)
+	response, err := tp.simulateTransaction(observers, tx, checkSignature)
 	if err != nil {
 		return nil, fmt.Errorf("%w while trying to simulate on sender shard (shard %d)", err, senderShardID)
 	}
@@ -190,7 +193,7 @@ func (tp *TransactionProcessor) SimulateTransaction(tx *data.Transaction) (*data
 		return nil, err
 	}
 
-	responseFromReceiverShard, err := tp.simulateTransaction(observersForReceiverShard, tx)
+	responseFromReceiverShard, err := tp.simulateTransaction(observersForReceiverShard, tx, checkSignature)
 	if err != nil {
 		return nil, fmt.Errorf("%w while trying to simulate on receiver shard (shard %d)", err, receiverShardID)
 	}
@@ -208,11 +211,20 @@ func (tp *TransactionProcessor) SimulateTransaction(tx *data.Transaction) (*data
 	}, nil
 }
 
-func (tp *TransactionProcessor) simulateTransaction(observers []*data.NodeData, tx *data.Transaction) (*data.ResponseTransactionSimulation, error) {
+func (tp *TransactionProcessor) simulateTransaction(
+	observers []*data.NodeData,
+	tx *data.Transaction,
+	checkSignature bool,
+) (*data.ResponseTransactionSimulation, error) {
+	txSimulatePath := TransactionSimulatePath
+	if !checkSignature {
+		txSimulatePath += checkSignatureFalse
+	}
+
 	for _, observer := range observers {
 		txResponse := &data.ResponseTransactionSimulation{}
 
-		respCode, err := tp.proc.CallPostRestEndPoint(observer.Address, TransactionSimulatePath, tx, txResponse)
+		respCode, err := tp.proc.CallPostRestEndPoint(observer.Address, txSimulatePath, tx, txResponse)
 		if respCode == http.StatusOK && err == nil {
 			log.Info(fmt.Sprintf("Transaction simulation sent successfully to observer %v from shard %v, received tx hash %s",
 				observer.Address,

--- a/process/transactionProcessor_test.go
+++ b/process/transactionProcessor_test.go
@@ -384,7 +384,7 @@ func TestTransactionProcessor_SimulateTransactionShouldWork(t *testing.T) {
 		marshalizer,
 	)
 
-	response, err := tp.SimulateTransaction(txsToSimulate)
+	response, err := tp.SimulateTransaction(txsToSimulate, true)
 	require.Nil(t, err)
 
 	respData := response.Data.(data.TransactionSimulationResponseData)
@@ -436,7 +436,7 @@ func TestTransactionProcessor_SimulateTransactionCrossShardOkOnSenderFailOnRecei
 		marshalizer,
 	)
 
-	response, err := tp.SimulateTransaction(txsToSimulate)
+	response, err := tp.SimulateTransaction(txsToSimulate, true)
 	require.Nil(t, err)
 
 	respData := response.Data.(data.TransactionSimulationResponseDataCrossShard)


### PR DESCRIPTION
Extend API route `/transaction/simulate` with an extra query parameter `checkSignature` in order to can simulate a transaction without the correct signature.

By default, if the user uses this API route without this parameter the transaction signature **will be verified**. 

In order to ignore the transaction signature user have to specify to ignore it (`?checkSignature=false`).