### PR TITLE
get all esdts roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ For more details, go to [docs.elrond.com](https://docs.elrond.com/sdk-and-tools/
 - `/v1.0/address/:address/esdt` (GET) --> returns the account's ESDT tokens list for the given :address.
 - `/v1.0/address/:address/esdt/:tokenIdentifier` (GET) --> returns the token data for a given :address and ESDT token, such as balance and properties.
 - `/v1.0/address/:address/esdts-with-role/:role` (GET) --> returns the token identifiers for a given :address and the provided role.
+- `/v1.0/address/:address/esdts/roles` (GET) --> returns the token identifiers and roles for a given :address
 - `/v1.0/address/:address/registered-nfts` (GET) --> returns the token identifiers of the NFTs registered by the given :address.
 - `/v1.0/address/:address/esdtnft/:tokenIdentifier/nonce/:nonce` (GET) --> returns the NFT token data for a given address, token identifier and nonce.
 

--- a/api/errors/errors.go
+++ b/api/errors/errors.go
@@ -23,6 +23,9 @@ var ErrGetESDTTokenData = errors.New("cannot get ESDT token data")
 // ErrGetESDTsWithRole signals an error in fetching an tokens with role for an address
 var ErrGetESDTsWithRole = errors.New("cannot get ESDTs with role")
 
+// ErrGetRolesForAccount signals an error in getting esdt tokens and roles for a given address
+var ErrGetRolesForAccount = errors.New("get roles for account error")
+
 // ErrGetESDTTokenData signals an error in fetching owned NFTs for an address
 var ErrGetNFTTokenIDsRegisteredByAddress = errors.New("cannot get owned NFTs for account")
 

--- a/api/groups/baseAccountsGroup.go
+++ b/api/groups/baseAccountsGroup.go
@@ -39,6 +39,7 @@ func NewAccountsGroup(facadeHandler data.FacadeHandler) (*accountsGroup, error) 
 		{Path: "/:address/esdt", Handler: ag.getESDTTokens, Method: http.MethodGet},
 		{Path: "/:address/esdt/:tokenIdentifier", Handler: ag.getESDTTokenData, Method: http.MethodGet},
 		{Path: "/:address/esdts-with-role/:role", Handler: ag.getESDTsWithRole, Method: http.MethodGet},
+		{Path: "/:address/esdts/roles", Handler: nil, Method: http.MethodGet},
 		{Path: "/:address/registered-nfts", Handler: ag.getRegisteredNFTs, Method: http.MethodGet},
 		{Path: "/:address/nft/:tokenIdentifier/nonce/:nonce", Handler: ag.getESDTNftTokenData, Method: http.MethodGet},
 	}
@@ -255,6 +256,34 @@ func (group *accountsGroup) getESDTTokenData(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, esdtTokenResponse)
+}
+
+func (group *accountsGroup) getESDTsRoles(c *gin.Context) {
+	addr := c.Param("address")
+	if addr == "" {
+		shared.RespondWith(
+			c,
+			http.StatusBadRequest,
+			nil,
+			fmt.Sprintf("%v: %v", errors.ErrGetESDTsWithRole, errors.ErrEmptyAddress),
+			data.ReturnCodeRequestError,
+		)
+		return
+	}
+
+	tokensRoles, err := group.facade.GetESDTsRoles(addr)
+	if err != nil {
+		shared.RespondWith(
+			c,
+			http.StatusInternalServerError,
+			nil,
+			err.Error(),
+			data.ReturnCodeInternalError,
+		)
+		return
+	}
+
+	c.JSON(http.StatusOK, tokensRoles)
 }
 
 // getESDTsWithRole returns the token identifiers of the tokens where  the given address has the given role

--- a/api/groups/baseAccountsGroup.go
+++ b/api/groups/baseAccountsGroup.go
@@ -39,7 +39,7 @@ func NewAccountsGroup(facadeHandler data.FacadeHandler) (*accountsGroup, error) 
 		{Path: "/:address/esdt", Handler: ag.getESDTTokens, Method: http.MethodGet},
 		{Path: "/:address/esdt/:tokenIdentifier", Handler: ag.getESDTTokenData, Method: http.MethodGet},
 		{Path: "/:address/esdts-with-role/:role", Handler: ag.getESDTsWithRole, Method: http.MethodGet},
-		{Path: "/:address/esdts/roles", Handler: nil, Method: http.MethodGet},
+		{Path: "/:address/esdts/roles", Handler: ag.getESDTsRoles, Method: http.MethodGet},
 		{Path: "/:address/registered-nfts", Handler: ag.getRegisteredNFTs, Method: http.MethodGet},
 		{Path: "/:address/nft/:tokenIdentifier/nonce/:nonce", Handler: ag.getESDTNftTokenData, Method: http.MethodGet},
 	}
@@ -265,7 +265,7 @@ func (group *accountsGroup) getESDTsRoles(c *gin.Context) {
 			c,
 			http.StatusBadRequest,
 			nil,
-			fmt.Sprintf("%v: %v", errors.ErrGetESDTsWithRole, errors.ErrEmptyAddress),
+			fmt.Sprintf("%v: %v", errors.ErrGetRolesForAccount, errors.ErrEmptyAddress),
 			data.ReturnCodeRequestError,
 		)
 		return

--- a/api/groups/interface.go
+++ b/api/groups/interface.go
@@ -17,6 +17,7 @@ type AccountsFacadeHandler interface {
 	GetKeyValuePairs(address string) (*data.GenericAPIResponse, error)
 	GetESDTTokenData(address string, key string) (*data.GenericAPIResponse, error)
 	GetESDTsWithRole(address string, role string) (*data.GenericAPIResponse, error)
+	GetESDTsRoles(address string) (*data.GenericAPIResponse, error)
 	GetESDTNftTokenData(address string, key string, nonce uint64) (*data.GenericAPIResponse, error)
 	GetNFTTokenIDsRegisteredByAddress(address string) (*data.GenericAPIResponse, error)
 }

--- a/api/mock/facade.go
+++ b/api/mock/facade.go
@@ -49,6 +49,7 @@ type Facade struct {
 	GetProofCalled                              func(string, string) (*data.GenericAPIResponse, error)
 	GetProofCurrentRootHashCalled               func(string) (*data.GenericAPIResponse, error)
 	VerifyProofCalled                           func(string, string, []string) (*data.GenericAPIResponse, error)
+	GetESDTsRolesCalled                         func(address string) (*data.GenericAPIResponse, error)
 }
 
 // GetProof -
@@ -145,6 +146,15 @@ func (f *Facade) GetAllIssuedESDTs(tokenType string) (*data.GenericAPIResponse, 
 func (f *Facade) GetESDTsWithRole(address string, role string) (*data.GenericAPIResponse, error) {
 	if f.GetESDTsWithRoleCalled != nil {
 		return f.GetESDTsWithRoleCalled(address, role)
+	}
+
+	return &data.GenericAPIResponse{}, nil
+}
+
+// GetESDTsRoles -
+func (f *Facade) GetESDTsRoles(address string) (*data.GenericAPIResponse, error) {
+	if f.GetESDTsRolesCalled != nil {
+		return f.GetESDTsRolesCalled(address)
 	}
 
 	return &data.GenericAPIResponse{}, nil

--- a/facade/baseFacade.go
+++ b/facade/baseFacade.go
@@ -129,7 +129,7 @@ func (epf *ElrondProxyFacade) GetESDTTokenData(address string, key string) (*dat
 	return epf.accountProc.GetESDTTokenData(address, key)
 }
 
-// GetESDTTokenData returns the token data for a given token name
+// GetESDTNftTokenData returns the token data for a given token name
 func (epf *ElrondProxyFacade) GetESDTNftTokenData(address string, key string, nonce uint64) (*data.GenericAPIResponse, error) {
 	return epf.accountProc.GetESDTNftTokenData(address, key, nonce)
 }
@@ -137,6 +137,11 @@ func (epf *ElrondProxyFacade) GetESDTNftTokenData(address string, key string, no
 // GetESDTsWithRole returns the tokens where the given address has the assigned role
 func (epf *ElrondProxyFacade) GetESDTsWithRole(address string, role string) (*data.GenericAPIResponse, error) {
 	return epf.accountProc.GetESDTsWithRole(address, role)
+}
+
+// GetESDTsRoles returns the tokens and roles for the given address
+func (epf *ElrondProxyFacade) GetESDTsRoles(address string) (*data.GenericAPIResponse, error) {
+	return epf.accountProc.GetESDTsRoles(address)
 }
 
 // GetNFTTokenIDsRegisteredByAddress returns the token identifiers of the NFTs registered by the address

--- a/facade/interface.go
+++ b/facade/interface.go
@@ -24,6 +24,7 @@ type AccountProcessor interface {
 	GetKeyValuePairs(address string) (*data.GenericAPIResponse, error)
 	GetESDTTokenData(address string, key string) (*data.GenericAPIResponse, error)
 	GetESDTsWithRole(address string, role string) (*data.GenericAPIResponse, error)
+	GetESDTsRoles(address string) (*data.GenericAPIResponse, error)
 	GetESDTNftTokenData(address string, key string, nonce uint64) (*data.GenericAPIResponse, error)
 	GetNFTTokenIDsRegisteredByAddress(address string) (*data.GenericAPIResponse, error)
 }

--- a/facade/mock/accountProccessorStub.go
+++ b/facade/mock/accountProccessorStub.go
@@ -17,6 +17,7 @@ type AccountProcessorStub struct {
 	GetESDTsWithRoleCalled                  func(address string, role string) (*data.GenericAPIResponse, error)
 	GetNFTTokenIDsRegisteredByAddressCalled func(address string) (*data.GenericAPIResponse, error)
 	GetKeyValuePairsCalled                  func(address string) (*data.GenericAPIResponse, error)
+	GetESDTsRolesCalled                     func(address string) (*data.GenericAPIResponse, error)
 }
 
 // GetKeyValuePairs -
@@ -42,6 +43,15 @@ func (aps *AccountProcessorStub) GetESDTNftTokenData(address string, key string,
 // GetESDTsWithRole -
 func (aps *AccountProcessorStub) GetESDTsWithRole(address string, role string) (*data.GenericAPIResponse, error) {
 	return aps.GetESDTsWithRoleCalled(address, role)
+}
+
+// GetESDTsRoles -
+func (aps *AccountProcessorStub) GetESDTsRoles(address string) (*data.GenericAPIResponse, error) {
+	if aps.GetESDTsRolesCalled != nil {
+		return aps.GetESDTsRolesCalled(address)
+	}
+
+	return &data.GenericAPIResponse{}, nil
 }
 
 // GetNFTTokenIDsRegisteredByAddress -

--- a/process/accountProcessor.go
+++ b/process/accountProcessor.go
@@ -163,6 +163,7 @@ func (ap *AccountProcessor) GetESDTsWithRole(address string, role string) (*data
 	return nil, ErrSendingRequest
 }
 
+// GetESDTsRoles returns all the tokens and their roles for a given address
 func (ap *AccountProcessor) GetESDTsRoles(address string) (*data.GenericAPIResponse, error) {
 	observers, err := ap.proc.GetObservers(core.MetachainShardId)
 	if err != nil {
@@ -186,7 +187,7 @@ func (ap *AccountProcessor) GetESDTsRoles(address string) (*data.GenericAPIRespo
 			return &apiResponse, nil
 		}
 
-		log.Error("account get ESDTs with role", "observer", observer.Address, "address", address, "error", errGet.Error())
+		log.Error("account get ESDTs roles", "observer", observer.Address, "address", address, "error", errGet.Error())
 	}
 
 	return nil, ErrSendingRequest

--- a/process/accountProcessor.go
+++ b/process/accountProcessor.go
@@ -172,9 +172,9 @@ func (ap *AccountProcessor) GetESDTsRoles(address string) (*data.GenericAPIRespo
 	for _, observer := range observers {
 		apiResponse := data.GenericAPIResponse{}
 		apiPath := AddressPath + address + "esdts/roles"
-		respCode, err := ap.proc.CallGetRestEndPoint(observer.Address, apiPath, &apiResponse)
-		if err == nil || respCode == http.StatusBadRequest || respCode == http.StatusInternalServerError {
-			log.Info("account ESDTs with role",
+		respCode, errGet := ap.proc.CallGetRestEndPoint(observer.Address, apiPath, &apiResponse)
+		if errGet == nil || respCode == http.StatusBadRequest || respCode == http.StatusInternalServerError {
+			log.Info("account ESDTs roles",
 				"address", address,
 				"shard ID", observer.ShardId,
 				"observer", observer.Address,
@@ -186,7 +186,7 @@ func (ap *AccountProcessor) GetESDTsRoles(address string) (*data.GenericAPIRespo
 			return &apiResponse, nil
 		}
 
-		log.Error("account get ESDTs with role", "observer", observer.Address, "address", address, "error", err.Error())
+		log.Error("account get ESDTs with role", "observer", observer.Address, "address", address, "error", errGet.Error())
 	}
 
 	return nil, ErrSendingRequest

--- a/process/accountProcessor.go
+++ b/process/accountProcessor.go
@@ -171,7 +171,7 @@ func (ap *AccountProcessor) GetESDTsRoles(address string) (*data.GenericAPIRespo
 
 	for _, observer := range observers {
 		apiResponse := data.GenericAPIResponse{}
-		apiPath := AddressPath + address + "esdts/roles"
+		apiPath := AddressPath + address + "/esdts/roles"
 		respCode, errGet := ap.proc.CallGetRestEndPoint(observer.Address, apiPath, &apiResponse)
 		if errGet == nil || respCode == http.StatusBadRequest || respCode == http.StatusInternalServerError {
 			log.Info("account ESDTs roles",


### PR DESCRIPTION
- Added a new API route /address/:address that will return all esdts tokens with roles 