### PR TITLE
API ESDT Supply

### DIFF
--- a/api/groups/baseNetworkGroup.go
+++ b/api/groups/baseNetworkGroup.go
@@ -147,7 +147,7 @@ func (group *networkGroup) getESDTSupply(c *gin.Context) {
 			c,
 			http.StatusBadRequest,
 			nil,
-			fmt.Sprintf("%v: %v", errors.ErrGetESDTTokenData, errors.ErrEmptyTokenIdentifier),
+			fmt.Sprintf("%s: %s", errors.ErrGetESDTTokenData.Error(), errors.ErrEmptyTokenIdentifier.Error()),
 			data.ReturnCodeRequestError,
 		)
 		return

--- a/api/groups/interface.go
+++ b/api/groups/interface.go
@@ -48,7 +48,7 @@ type NetworkFacadeHandler interface {
 	GetDirectStakedInfo() (*data.GenericAPIResponse, error)
 	GetDelegatedInfo() (*data.GenericAPIResponse, error)
 	GetEnableEpochsMetrics() (*data.GenericAPIResponse, error)
-	GetESDTSupply(token string) (*data.GenericAPIResponse, error)
+	GetESDTSupply(token string) (*data.ESDTSupplyResponse, error)
 }
 
 // NodeFacadeHandler interface defines methods that can be used from facade context variable

--- a/api/groups/interface.go
+++ b/api/groups/interface.go
@@ -48,6 +48,7 @@ type NetworkFacadeHandler interface {
 	GetDirectStakedInfo() (*data.GenericAPIResponse, error)
 	GetDelegatedInfo() (*data.GenericAPIResponse, error)
 	GetEnableEpochsMetrics() (*data.GenericAPIResponse, error)
+	GetESDTSupply(token string) (*data.GenericAPIResponse, error)
 }
 
 // NodeFacadeHandler interface defines methods that can be used from facade context variable

--- a/api/mock/facade.go
+++ b/api/mock/facade.go
@@ -50,6 +50,7 @@ type Facade struct {
 	GetProofCurrentRootHashCalled               func(string) (*data.GenericAPIResponse, error)
 	VerifyProofCalled                           func(string, string, []string) (*data.GenericAPIResponse, error)
 	GetESDTsRolesCalled                         func(address string) (*data.GenericAPIResponse, error)
+	GetESDTSupplyCalled                         func(token string) (*data.GenericAPIResponse, error)
 }
 
 // GetProof -
@@ -190,6 +191,14 @@ func (f *Facade) GetDelegatedInfo() (*data.GenericAPIResponse, error) {
 // GetEnableEpochsMetrics -
 func (f *Facade) GetEnableEpochsMetrics() (*data.GenericAPIResponse, error) {
 	return f.GetEnableEpochsMetricsHandler()
+}
+
+func (f *Facade) GetESDTSupply(token string) (*data.GenericAPIResponse, error) {
+	if f.GetESDTSupplyCalled != nil {
+		return f.GetESDTSupplyCalled(token)
+	}
+
+	return nil, nil
 }
 
 // ValidatorStatistics -

--- a/api/mock/facade.go
+++ b/api/mock/facade.go
@@ -50,7 +50,7 @@ type Facade struct {
 	GetProofCurrentRootHashCalled               func(string) (*data.GenericAPIResponse, error)
 	VerifyProofCalled                           func(string, string, []string) (*data.GenericAPIResponse, error)
 	GetESDTsRolesCalled                         func(address string) (*data.GenericAPIResponse, error)
-	GetESDTSupplyCalled                         func(token string) (*data.GenericAPIResponse, error)
+	GetESDTSupplyCalled                         func(token string) (*data.ESDTSupplyResponse, error)
 }
 
 // GetProof -
@@ -193,7 +193,7 @@ func (f *Facade) GetEnableEpochsMetrics() (*data.GenericAPIResponse, error) {
 	return f.GetEnableEpochsMetricsHandler()
 }
 
-func (f *Facade) GetESDTSupply(token string) (*data.GenericAPIResponse, error) {
+func (f *Facade) GetESDTSupply(token string) (*data.ESDTSupplyResponse, error) {
 	if f.GetESDTSupplyCalled != nil {
 		return f.GetESDTSupplyCalled(token)
 	}

--- a/api/mock/facade.go
+++ b/api/mock/facade.go
@@ -193,6 +193,7 @@ func (f *Facade) GetEnableEpochsMetrics() (*data.GenericAPIResponse, error) {
 	return f.GetEnableEpochsMetricsHandler()
 }
 
+// GetESDTSupply -
 func (f *Facade) GetESDTSupply(token string) (*data.ESDTSupplyResponse, error) {
 	if f.GetESDTSupplyCalled != nil {
 		return f.GetESDTSupplyCalled(token)

--- a/cmd/proxy/config/apiConfig/v1_0.toml
+++ b/cmd/proxy/config/apiConfig/v1_0.toml
@@ -52,6 +52,7 @@ Routes = [
     { Name = "/esdt/fungible-tokens", Open = true, Secured = false, RateLimit = 0 },
     { Name = "/esdt/semi-fungible-tokens", Open = true, Secured = false, RateLimit = 0 },
     { Name = "/esdt/non-fungible-tokens", Open = true, Secured = false, RateLimit = 0 },
+    { Name = "/esdt/supply/:token", Open = true, Secured = false, RateLimit = 0 },
     { Name = "/direct-staked-info", Open = true, Secured = true, RateLimit = 0 },
     { Name = "/delegated-info", Open = true, Secured = true, RateLimit = 0 },
     { Name = "/enable-epochs", Open = false, Secured = false, RateLimit = 0 }

--- a/cmd/proxy/config/apiConfig/v_next.toml
+++ b/cmd/proxy/config/apiConfig/v_next.toml
@@ -52,6 +52,7 @@ Routes = [
     { Name = "/esdt/fungible-tokens", Open = true, Secured = false, RateLimit = 0 },
     { Name = "/esdt/semi-fungible-tokens", Open = true, Secured = false, RateLimit = 0 },
     { Name = "/esdt/non-fungible-tokens", Open = true, Secured = false, RateLimit = 0 },
+    { Name = "/esdt/supply/:token", Open = true, Secured = false, RateLimit = 0 },
     { Name = "/direct-staked-info", Open = true, Secured = true, RateLimit = 0 },
     { Name = "/delegated-info", Open = true, Secured = true, RateLimit = 0 },
     { Name = "/enable-epochs", Open = true, Secured = false, RateLimit = 0 }

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -523,7 +523,7 @@ func createVersionsRegistry(
 		return nil, err
 	}
 
-	esdtSuppliesProc, err := process.NewESDTSuppliesProcessor(bp, scQueryProc)
+	esdtSuppliesProc, err := process.NewESDTSupplyProcessor(bp, scQueryProc)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -137,7 +137,7 @@ VERSION:
 			" log level.",
 		Value: "*:" + logger.LogInfo.String(),
 	}
-	//logFile is used when the log output needs to be logged in a file
+	// logFile is used when the log output needs to be logged in a file
 	logSaveFile = cli.BoolFlag{
 		Name:  "log-save",
 		Usage: "Boolean option for enabling log saving. If set, it will automatically save all the logs into a file.",
@@ -523,6 +523,11 @@ func createVersionsRegistry(
 		return nil, err
 	}
 
+	esdtSuppliesProc, err := process.NewESDTSuppliesProcessor(bp, scQueryProc)
+	if err != nil {
+		return nil, err
+	}
+
 	facadeArgs := versionsFactory.FacadeArgs{
 		ActionsProcessor:             bp,
 		AccountProcessor:             accntProc,
@@ -535,6 +540,7 @@ func createVersionsRegistry(
 		ValidatorStatisticsProcessor: valStatsProc,
 		ProofProcessor:               proofProc,
 		PubKeyConverter:              pubKeyConverter,
+		ESDTSuppliesProcessor:        esdtSuppliesProc,
 	}
 
 	apiConfigParser, err := versionsFactory.NewApiConfigParser(apiConfigDirectoryPath)

--- a/data/esdt.go
+++ b/data/esdt.go
@@ -9,6 +9,17 @@ const (
 // ValidTokenTypes holds a slice containing the valid esdt token types
 var ValidTokenTypes = []string{FungibleTokens, SemiFungibleTokens, NonFungibleTokens}
 
+// ESDTSupplyResponse is a response holding esdt supply
+type ESDTSupplyResponse struct {
+	Data  ESDTSupply `json:"data"`
+	Error string     `json:"error"`
+	Code  ReturnCode `json:"code"`
+}
+
+type ESDTSupply struct {
+	Supply string `json:"supply"`
+}
+
 // IsValidEsdtPath returns true if the provided path is a valid esdt token type
 func IsValidEsdtPath(path string) bool {
 	for _, tokenType := range ValidTokenTypes {

--- a/data/esdt.go
+++ b/data/esdt.go
@@ -16,6 +16,7 @@ type ESDTSupplyResponse struct {
 	Code  ReturnCode `json:"code"`
 }
 
+// ESDTSupply is a DTO holding esdt supply
 type ESDTSupply struct {
 	Supply string `json:"supply"`
 }

--- a/facade/baseFacade.go
+++ b/facade/baseFacade.go
@@ -25,16 +25,17 @@ var _ groups.ProofFacadeHandler = (*ElrondProxyFacade)(nil)
 
 // ElrondProxyFacade implements the facade used in api calls
 type ElrondProxyFacade struct {
-	actionsProc    ActionsProcessor
-	accountProc    AccountProcessor
-	txProc         TransactionProcessor
-	scQueryService SCQueryService
-	heartbeatProc  HeartbeatProcessor
-	valStatsProc   ValidatorStatisticsProcessor
-	faucetProc     FaucetProcessor
-	nodeStatusProc NodeStatusProcessor
-	blockProc      BlockProcessor
-	proofProc      ProofProcessor
+	actionsProc      ActionsProcessor
+	accountProc      AccountProcessor
+	txProc           TransactionProcessor
+	scQueryService   SCQueryService
+	heartbeatProc    HeartbeatProcessor
+	valStatsProc     ValidatorStatisticsProcessor
+	faucetProc       FaucetProcessor
+	nodeStatusProc   NodeStatusProcessor
+	blockProc        BlockProcessor
+	proofProc        ProofProcessor
+	esdtSuppliesProc ESDTSuppliesProcessor
 
 	pubKeyConverter core.PubkeyConverter
 }
@@ -52,6 +53,7 @@ func NewElrondProxyFacade(
 	blockProc BlockProcessor,
 	proofProc ProofProcessor,
 	pubKeyConverter core.PubkeyConverter,
+	esdtSuppliesProc ESDTSuppliesProcessor,
 ) (*ElrondProxyFacade, error) {
 	if actionsProc == nil {
 		return nil, ErrNilActionsProcessor
@@ -83,19 +85,23 @@ func NewElrondProxyFacade(
 	if proofProc == nil {
 		return nil, ErrNilProofProcessor
 	}
+	if esdtSuppliesProc == nil {
+		return nil, ErrNilESDTSuppliesProcessor
+	}
 
 	return &ElrondProxyFacade{
-		actionsProc:     actionsProc,
-		accountProc:     accountProc,
-		txProc:          txProc,
-		scQueryService:  scQueryService,
-		heartbeatProc:   heartbeatProc,
-		valStatsProc:    valStatsProc,
-		faucetProc:      faucetProc,
-		nodeStatusProc:  nodeStatusProc,
-		blockProc:       blockProc,
-		proofProc:       proofProc,
-		pubKeyConverter: pubKeyConverter,
+		actionsProc:      actionsProc,
+		accountProc:      accountProc,
+		txProc:           txProc,
+		scQueryService:   scQueryService,
+		heartbeatProc:    heartbeatProc,
+		valStatsProc:     valStatsProc,
+		faucetProc:       faucetProc,
+		nodeStatusProc:   nodeStatusProc,
+		blockProc:        blockProc,
+		proofProc:        proofProc,
+		pubKeyConverter:  pubKeyConverter,
+		esdtSuppliesProc: esdtSuppliesProc,
 	}, nil
 }
 
@@ -290,7 +296,12 @@ func (epf *ElrondProxyFacade) GetNetworkStatusMetrics(shardID uint32) (*data.Gen
 	return epf.nodeStatusProc.GetNetworkStatusMetrics(shardID)
 }
 
-// GetNetworkStatusMetrics retrieves the node's network metrics for a given shard
+// GetESDTSupply retrieves the supply for the provided token
+func (epf *ElrondProxyFacade) GetESDTSupply(token string) (*data.GenericAPIResponse, error) {
+	return epf.esdtSuppliesProc.GetESDTSupply(token)
+}
+
+// GetEconomicsDataMetrics retrieves the node's network metrics for a given shard
 func (epf *ElrondProxyFacade) GetEconomicsDataMetrics() (*data.GenericAPIResponse, error) {
 	return epf.nodeStatusProc.GetEconomicsDataMetrics()
 }
@@ -300,7 +311,7 @@ func (epf *ElrondProxyFacade) GetDelegatedInfo() (*data.GenericAPIResponse, erro
 	return epf.nodeStatusProc.GetDelegatedInfo()
 }
 
-// GetDirectStaked retrieves the node's direct staked values
+// GetDirectStakedInfo retrieves the node's direct staked values
 func (epf *ElrondProxyFacade) GetDirectStakedInfo() (*data.GenericAPIResponse, error) {
 	return epf.nodeStatusProc.GetDirectStakedInfo()
 }

--- a/facade/baseFacade.go
+++ b/facade/baseFacade.go
@@ -35,7 +35,7 @@ type ElrondProxyFacade struct {
 	nodeStatusProc   NodeStatusProcessor
 	blockProc        BlockProcessor
 	proofProc        ProofProcessor
-	esdtSuppliesProc ESDTSuppliesProcessor
+	esdtSuppliesProc ESDTSupplyProcessor
 
 	pubKeyConverter core.PubkeyConverter
 }
@@ -53,7 +53,7 @@ func NewElrondProxyFacade(
 	blockProc BlockProcessor,
 	proofProc ProofProcessor,
 	pubKeyConverter core.PubkeyConverter,
-	esdtSuppliesProc ESDTSuppliesProcessor,
+	esdtSuppliesProc ESDTSupplyProcessor,
 ) (*ElrondProxyFacade, error) {
 	if actionsProc == nil {
 		return nil, ErrNilActionsProcessor

--- a/facade/baseFacade.go
+++ b/facade/baseFacade.go
@@ -297,7 +297,7 @@ func (epf *ElrondProxyFacade) GetNetworkStatusMetrics(shardID uint32) (*data.Gen
 }
 
 // GetESDTSupply retrieves the supply for the provided token
-func (epf *ElrondProxyFacade) GetESDTSupply(token string) (*data.GenericAPIResponse, error) {
+func (epf *ElrondProxyFacade) GetESDTSupply(token string) (*data.ESDTSupplyResponse, error) {
 	return epf.esdtSuppliesProc.GetESDTSupply(token)
 }
 

--- a/facade/baseFacade_test.go
+++ b/facade/baseFacade_test.go
@@ -33,6 +33,7 @@ func TestNewElrondProxyFacade_NilActionsProcShouldErr(t *testing.T) {
 		&mock.BlockProcessorStub{},
 		&mock.ProofProcessorStub{},
 		publicKeyConverter,
+		&mock.ESDTSuppliesProcessorStub{},
 	)
 
 	assert.Nil(t, epf)
@@ -54,6 +55,7 @@ func TestNewElrondProxyFacade_NilAccountProcShouldErr(t *testing.T) {
 		&mock.BlockProcessorStub{},
 		&mock.ProofProcessorStub{},
 		publicKeyConverter,
+		&mock.ESDTSuppliesProcessorStub{},
 	)
 
 	assert.Nil(t, epf)
@@ -75,6 +77,7 @@ func TestNewElrondProxyFacade_NilTransactionProcShouldErr(t *testing.T) {
 		&mock.BlockProcessorStub{},
 		&mock.ProofProcessorStub{},
 		publicKeyConverter,
+		&mock.ESDTSuppliesProcessorStub{},
 	)
 
 	assert.Nil(t, epf)
@@ -96,6 +99,7 @@ func TestNewElrondProxyFacade_NilGetValuesProcShouldErr(t *testing.T) {
 		&mock.BlockProcessorStub{},
 		&mock.ProofProcessorStub{},
 		publicKeyConverter,
+		&mock.ESDTSuppliesProcessorStub{},
 	)
 
 	assert.Nil(t, epf)
@@ -117,6 +121,7 @@ func TestNewElrondProxyFacade_NilHeartbeatProcShouldErr(t *testing.T) {
 		&mock.BlockProcessorStub{},
 		&mock.ProofProcessorStub{},
 		publicKeyConverter,
+		&mock.ESDTSuppliesProcessorStub{},
 	)
 
 	assert.Nil(t, epf)
@@ -138,6 +143,7 @@ func TestNewElrondProxyFacade_NilValStatsProcShouldErr(t *testing.T) {
 		&mock.BlockProcessorStub{},
 		&mock.ProofProcessorStub{},
 		publicKeyConverter,
+		&mock.ESDTSuppliesProcessorStub{},
 	)
 
 	assert.Nil(t, epf)
@@ -159,6 +165,7 @@ func TestNewElrondProxyFacade_NilFaucetProcShouldErr(t *testing.T) {
 		&mock.BlockProcessorStub{},
 		&mock.ProofProcessorStub{},
 		publicKeyConverter,
+		&mock.ESDTSuppliesProcessorStub{},
 	)
 
 	assert.Nil(t, epf)
@@ -180,6 +187,7 @@ func TestNewElrondProxyFacade_NilNodeProcessor(t *testing.T) {
 		&mock.BlockProcessorStub{},
 		&mock.ProofProcessorStub{},
 		publicKeyConverter,
+		&mock.ESDTSuppliesProcessorStub{},
 	)
 
 	assert.Nil(t, epf)
@@ -201,6 +209,7 @@ func TestNewElrondProxyFacade_NilProofProcessor(t *testing.T) {
 		&mock.BlockProcessorStub{},
 		nil,
 		publicKeyConverter,
+		&mock.ESDTSuppliesProcessorStub{},
 	)
 
 	assert.Nil(t, epf)
@@ -222,6 +231,7 @@ func TestNewElrondProxyFacade_ShouldWork(t *testing.T) {
 		&mock.BlockProcessorStub{},
 		&mock.ProofProcessorStub{},
 		publicKeyConverter,
+		&mock.ESDTSuppliesProcessorStub{},
 	)
 
 	assert.NotNil(t, epf)
@@ -249,6 +259,7 @@ func TestElrondProxyFacade_GetAccount(t *testing.T) {
 		&mock.BlockProcessorStub{},
 		&mock.ProofProcessorStub{},
 		publicKeyConverter,
+		&mock.ESDTSuppliesProcessorStub{},
 	)
 
 	_, _ = epf.GetAccount("")
@@ -278,6 +289,7 @@ func TestElrondProxyFacade_SendTransaction(t *testing.T) {
 		&mock.BlockProcessorStub{},
 		&mock.ProofProcessorStub{},
 		publicKeyConverter,
+		&mock.ESDTSuppliesProcessorStub{},
 	)
 
 	_, _, _ = epf.SendTransaction(&data.Transaction{})
@@ -306,6 +318,7 @@ func TestElrondProxyFacade_SimulateTransaction(t *testing.T) {
 		&mock.BlockProcessorStub{},
 		&mock.ProofProcessorStub{},
 		publicKeyConverter,
+		&mock.ESDTSuppliesProcessorStub{},
 	)
 
 	_, _ = epf.SimulateTransaction(&data.Transaction{}, false)
@@ -358,6 +371,7 @@ func TestElrondProxyFacade_SendUserFunds(t *testing.T) {
 		&mock.BlockProcessorStub{},
 		&mock.ProofProcessorStub{},
 		publicKeyConverter,
+		&mock.ESDTSuppliesProcessorStub{},
 	)
 
 	_ = epf.SendUserFunds("", big.NewInt(0))
@@ -386,6 +400,7 @@ func TestElrondProxyFacade_GetDataValue(t *testing.T) {
 		&mock.BlockProcessorStub{},
 		&mock.ProofProcessorStub{},
 		publicKeyConverter,
+		&mock.ESDTSuppliesProcessorStub{},
 	)
 
 	_, _ = epf.ExecuteSCQuery(nil)
@@ -420,6 +435,7 @@ func TestElrondProxyFacade_GetHeartbeatData(t *testing.T) {
 		&mock.BlockProcessorStub{},
 		&mock.ProofProcessorStub{},
 		publicKeyConverter,
+		&mock.ESDTSuppliesProcessorStub{},
 	)
 
 	actualResult, _ := epf.GetHeartbeatData()
@@ -451,6 +467,7 @@ func TestElrondProxyFacade_ReloadObservers(t *testing.T) {
 		&mock.BlockProcessorStub{},
 		&mock.ProofProcessorStub{},
 		publicKeyConverter,
+		&mock.ESDTSuppliesProcessorStub{},
 	)
 
 	actualResult := epf.ReloadObservers()
@@ -482,6 +499,7 @@ func TestElrondProxyFacade_ReloadFullHistoryObservers(t *testing.T) {
 		&mock.BlockProcessorStub{},
 		&mock.ProofProcessorStub{},
 		publicKeyConverter,
+		&mock.ESDTSuppliesProcessorStub{},
 	)
 
 	actualResult := epf.ReloadFullHistoryObservers()

--- a/facade/errors.go
+++ b/facade/errors.go
@@ -31,3 +31,6 @@ var ErrNilBlockProcessor = errors.New("nil block processor provided")
 
 // ErrNilProofProcessor signals that a nil proof processor has been provided
 var ErrNilProofProcessor = errors.New("nil proof processor provided")
+
+// ErrNilESDTSuppliesProcessor signals that a nil esdt supplies processor has been provided
+var ErrNilESDTSuppliesProcessor = errors.New("nil esdt supplies processor")

--- a/facade/interface.go
+++ b/facade/interface.go
@@ -63,6 +63,11 @@ type ValidatorStatisticsProcessor interface {
 	GetValidatorStatistics() (*data.ValidatorStatisticsResponse, error)
 }
 
+// ESDTSuppliesProcessor defines what an esdt supplies processor should do
+type ESDTSuppliesProcessor interface {
+	GetESDTSupply(token string) (*data.GenericAPIResponse, error)
+}
+
 // NodeStatusProcessor defines what a node status processor should do
 type NodeStatusProcessor interface {
 	GetNetworkConfigMetrics() (*data.GenericAPIResponse, error)

--- a/facade/interface.go
+++ b/facade/interface.go
@@ -63,8 +63,8 @@ type ValidatorStatisticsProcessor interface {
 	GetValidatorStatistics() (*data.ValidatorStatisticsResponse, error)
 }
 
-// ESDTSuppliesProcessor defines what an esdt supplies processor should do
-type ESDTSuppliesProcessor interface {
+// ESDTSupplyProcessor defines what an esdt supply processor should do
+type ESDTSupplyProcessor interface {
 	GetESDTSupply(token string) (*data.ESDTSupplyResponse, error)
 }
 

--- a/facade/interface.go
+++ b/facade/interface.go
@@ -65,7 +65,7 @@ type ValidatorStatisticsProcessor interface {
 
 // ESDTSuppliesProcessor defines what an esdt supplies processor should do
 type ESDTSuppliesProcessor interface {
-	GetESDTSupply(token string) (*data.GenericAPIResponse, error)
+	GetESDTSupply(token string) (*data.ESDTSupplyResponse, error)
 }
 
 // NodeStatusProcessor defines what a node status processor should do

--- a/facade/mock/esdtSuppliesProcessorStub.go
+++ b/facade/mock/esdtSuppliesProcessorStub.go
@@ -1,0 +1,17 @@
+package mock
+
+import "github.com/ElrondNetwork/elrond-proxy-go/data"
+
+// ESDTSuppliesProcessorStub -
+type ESDTSuppliesProcessorStub struct {
+	GetESDTSupplyCalled func(token string) (*data.GenericAPIResponse, error)
+}
+
+// GetESDTSupply -
+func (e *ESDTSuppliesProcessorStub) GetESDTSupply(token string) (*data.GenericAPIResponse, error) {
+	if e.GetESDTSupplyCalled != nil {
+		return e.GetESDTSupplyCalled(token)
+	}
+
+	return nil, nil
+}

--- a/facade/mock/esdtSuppliesProcessorStub.go
+++ b/facade/mock/esdtSuppliesProcessorStub.go
@@ -4,11 +4,11 @@ import "github.com/ElrondNetwork/elrond-proxy-go/data"
 
 // ESDTSuppliesProcessorStub -
 type ESDTSuppliesProcessorStub struct {
-	GetESDTSupplyCalled func(token string) (*data.GenericAPIResponse, error)
+	GetESDTSupplyCalled func(token string) (*data.ESDTSupplyResponse, error)
 }
 
 // GetESDTSupply -
-func (e *ESDTSuppliesProcessorStub) GetESDTSupply(token string) (*data.GenericAPIResponse, error) {
+func (e *ESDTSuppliesProcessorStub) GetESDTSupply(token string) (*data.ESDTSupplyResponse, error) {
 	if e.GetESDTSupplyCalled != nil {
 		return e.GetESDTSupplyCalled(token)
 	}

--- a/facade/mock/scQueryServiceStub.go
+++ b/facade/mock/scQueryServiceStub.go
@@ -5,12 +5,12 @@ import (
 	"github.com/ElrondNetwork/elrond-proxy-go/data"
 )
 
-// SCQueryServiceStub is a stub
+// SCQueryServiceStub -
 type SCQueryServiceStub struct {
 	ExecuteQueryCalled func(*data.SCQuery) (*vm.VMOutputApi, error)
 }
 
-// ExecuteQuery is a stub
+// ExecuteQuery -
 func (serviceStub *SCQueryServiceStub) ExecuteQuery(query *data.SCQuery) (*vm.VMOutputApi, error) {
 	return serviceStub.ExecuteQueryCalled(query)
 }

--- a/process/baseProcessor.go
+++ b/process/baseProcessor.go
@@ -282,7 +282,7 @@ func (bp *BaseProcessor) GetPubKeyConverter() core.PubkeyConverter {
 	return bp.pubKeyConverter
 }
 
-// GetObserversProvider returns the observers provider
+// GetObserverProvider returns the observers provider
 func (bp *BaseProcessor) GetObserverProvider() observer.NodesProviderHandler {
 	return bp.observersProvider
 }

--- a/process/errors.go
+++ b/process/errors.go
@@ -97,3 +97,6 @@ var ErrInvalidTokenType = errors.New("invalid token type")
 
 // ErrNilLogsMerger signals that the provided logs merger is nil
 var ErrNilLogsMerger = errors.New("nil logs merger")
+
+// ErrNilSCQueryService signals that a nil smart contracts query service has been provided
+var ErrNilSCQueryService = errors.New("nil smart contracts query service provided")

--- a/process/esdtSuppliesProcessor.go
+++ b/process/esdtSuppliesProcessor.go
@@ -93,7 +93,8 @@ func (esp *esdtSuppliesProcessor) getInitialSupplyFromMeta(token string) (*big.I
 	}
 
 	supplyBytes := res.ReturnData[3]
-	return big.NewInt(0).SetBytes(supplyBytes), nil
+	supplyBig, _ := big.NewInt(0).SetString(string(supplyBytes), 10)
+	return supplyBig, nil
 }
 
 func (esp *esdtSuppliesProcessor) getShardSupply(token string, shardID uint32) (*big.Int, error) {

--- a/process/esdtSuppliesProcessor.go
+++ b/process/esdtSuppliesProcessor.go
@@ -3,10 +3,22 @@ package process
 import "github.com/ElrondNetwork/elrond-proxy-go/data"
 
 type esdtSuppliesProcessor struct {
+	baseProc    Processor
+	scQueryProc SCQueryService
 }
 
-func NewESDTSuppliesProcessor() (*esdtSuppliesProcessor, error) {
-	return &esdtSuppliesProcessor{}, nil
+func NewESDTSuppliesProcessor(baseProc Processor, scQueryProc SCQueryService) (*esdtSuppliesProcessor, error) {
+	if baseProc == nil {
+		return nil, ErrNilCoreProcessor
+	}
+	if scQueryProc == nil {
+		return nil, ErrNilSCQueryService
+	}
+
+	return &esdtSuppliesProcessor{
+		baseProc:    baseProc,
+		scQueryProc: scQueryProc,
+	}, nil
 }
 
 func (esp *esdtSuppliesProcessor) GetESDTSupply(token string) (*data.GenericAPIResponse, error) {

--- a/process/esdtSuppliesProcessor.go
+++ b/process/esdtSuppliesProcessor.go
@@ -4,6 +4,7 @@ import (
 	"math/big"
 	"strings"
 
+	"github.com/ElrondNetwork/elrond-go-logger/check"
 	"github.com/ElrondNetwork/elrond-go/core"
 	"github.com/ElrondNetwork/elrond-proxy-go/data"
 )
@@ -20,11 +21,12 @@ type esdtSuppliesProcessor struct {
 	scQueryProc SCQueryService
 }
 
+// NewESDTSuppliesProcessor will create a new instance of the ESDT supplies processor
 func NewESDTSuppliesProcessor(baseProc Processor, scQueryProc SCQueryService) (*esdtSuppliesProcessor, error) {
-	if baseProc == nil {
+	if check.IfNil(baseProc) {
 		return nil, ErrNilCoreProcessor
 	}
-	if scQueryProc == nil {
+	if check.IfNil(scQueryProc) {
 		return nil, ErrNilSCQueryService
 	}
 
@@ -34,6 +36,7 @@ func NewESDTSuppliesProcessor(baseProc Processor, scQueryProc SCQueryService) (*
 	}, nil
 }
 
+// GetESDTSupply will return the total supply for the provided token
 func (esp *esdtSuppliesProcessor) GetESDTSupply(tokenIdentifier string) (*data.ESDTSupplyResponse, error) {
 	totalSupply, err := esp.getSupplyFromShards(tokenIdentifier)
 	if err != nil {
@@ -113,7 +116,7 @@ func (esp *esdtSuppliesProcessor) getShardSupply(token string, shardID uint32) (
 			continue
 		}
 
-		log.Info("network metrics request", "shard ID", observer.ShardId, "observer", observer.Address)
+		log.Info("esdt supply request", "shard ID", observer.ShardId, "observer", observer.Address)
 
 		if responseEsdtSupply.Data.Supply == "" {
 			return big.NewInt(0), nil

--- a/process/esdtSuppliesProcessor.go
+++ b/process/esdtSuppliesProcessor.go
@@ -1,0 +1,14 @@
+package process
+
+import "github.com/ElrondNetwork/elrond-proxy-go/data"
+
+type esdtSuppliesProcessor struct {
+}
+
+func NewESDTSuppliesProcessor() (*esdtSuppliesProcessor, error) {
+	return &esdtSuppliesProcessor{}, nil
+}
+
+func (esp *esdtSuppliesProcessor) GetESDTSupply(token string) (*data.GenericAPIResponse, error) {
+	return nil, nil
+}

--- a/process/esdtSuppliesProcessor.go
+++ b/process/esdtSuppliesProcessor.go
@@ -1,6 +1,20 @@
 package process
 
-import "github.com/ElrondNetwork/elrond-proxy-go/data"
+import (
+	"encoding/hex"
+	"math/big"
+	"strings"
+
+	"github.com/ElrondNetwork/elrond-go/core"
+	"github.com/ElrondNetwork/elrond-proxy-go/data"
+)
+
+const (
+	esdtContractAddress   = "erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u"
+	initialESDTSupplyFunc = "getTokenProperties"
+
+	networkESDTSupplyPath = "/network/esdt/supply/"
+)
 
 type esdtSuppliesProcessor struct {
 	baseProc    Processor
@@ -21,6 +35,98 @@ func NewESDTSuppliesProcessor(baseProc Processor, scQueryProc SCQueryService) (*
 	}, nil
 }
 
-func (esp *esdtSuppliesProcessor) GetESDTSupply(token string) (*data.GenericAPIResponse, error) {
-	return nil, nil
+func (esp *esdtSuppliesProcessor) GetESDTSupply(tokenIdentifier string) (*data.ESDTSupplyResponse, error) {
+	totalSupply, err := esp.getSupplyFromShards(tokenIdentifier)
+	if err != nil {
+		return nil, err
+	}
+
+	res := &data.ESDTSupplyResponse{}
+	if !isFungibleESDT(tokenIdentifier) {
+		res.Data.Supply = totalSupply.String()
+		return res, nil
+	}
+
+	initialSupply, err := esp.getInitialSupplyFromMeta(tokenIdentifier)
+	if err != nil {
+		return nil, err
+	}
+
+	totalSupply.Add(totalSupply, initialSupply)
+	res.Data.Supply = totalSupply.String()
+
+	return res, nil
+}
+
+func (esp *esdtSuppliesProcessor) getSupplyFromShards(tokenIdentifier string) (*big.Int, error) {
+	totalSupply := big.NewInt(0)
+	shardIDSs := esp.baseProc.GetShardIDs()
+	for _, shardID := range shardIDSs {
+		if shardID == core.MetachainShardId {
+			continue
+		}
+
+		supply, err := esp.getShardSupply(tokenIdentifier, shardID)
+		if err != nil {
+			return nil, err
+		}
+
+		totalSupply.Add(totalSupply, supply)
+	}
+
+	return totalSupply, nil
+}
+
+func (esp *esdtSuppliesProcessor) getInitialSupplyFromMeta(token string) (*big.Int, error) {
+	hexEncodedToken := []byte(hex.EncodeToString([]byte(token)))
+
+	scQuery := &data.SCQuery{
+		ScAddress: esdtContractAddress,
+		FuncName:  initialESDTSupplyFunc,
+		Arguments: [][]byte{hexEncodedToken},
+	}
+
+	res, err := esp.scQueryProc.ExecuteQuery(scQuery)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(res.ReturnData) < 4 {
+		return big.NewInt(0), nil
+	}
+
+	supplyBytes := res.ReturnData[3]
+	return big.NewInt(0).SetBytes(supplyBytes), nil
+}
+
+func (esp *esdtSuppliesProcessor) getShardSupply(token string, shardID uint32) (*big.Int, error) {
+	shardObservers, errObs := esp.baseProc.GetObservers(shardID)
+	if errObs != nil {
+		return nil, errObs
+	}
+
+	apiPath := networkESDTSupplyPath + token
+	for _, observer := range shardObservers {
+		var responseEsdtSupply *data.ESDTSupplyResponse
+
+		_, errGet := esp.baseProc.CallGetRestEndPoint(observer.Address, apiPath, &responseEsdtSupply)
+		if errGet != nil {
+			log.Error("network metrics request", "observer", observer.Address, "error", errGet.Error())
+			continue
+		}
+
+		log.Info("network metrics request", "shard ID", observer.ShardId, "observer", observer.Address)
+
+		bigValue, _ := big.NewInt(0).SetString(responseEsdtSupply.Data.Supply, 10)
+		return bigValue, nil
+
+	}
+
+	return nil, ErrSendingRequest
+}
+
+func isFungibleESDT(tokenIdentifier string) bool {
+	splitToken := strings.Split(tokenIdentifier, "-")
+
+	return len(splitToken) < 3
 }

--- a/process/esdtSuppliesProcessor.go
+++ b/process/esdtSuppliesProcessor.go
@@ -1,7 +1,6 @@
 package process
 
 import (
-	"encoding/hex"
 	"math/big"
 	"strings"
 
@@ -78,12 +77,10 @@ func (esp *esdtSuppliesProcessor) getSupplyFromShards(tokenIdentifier string) (*
 }
 
 func (esp *esdtSuppliesProcessor) getInitialSupplyFromMeta(token string) (*big.Int, error) {
-	hexEncodedToken := []byte(hex.EncodeToString([]byte(token)))
-
 	scQuery := &data.SCQuery{
 		ScAddress: esdtContractAddress,
 		FuncName:  initialESDTSupplyFunc,
-		Arguments: [][]byte{hexEncodedToken},
+		Arguments: [][]byte{[]byte(token)},
 	}
 
 	res, err := esp.scQueryProc.ExecuteQuery(scQuery)
@@ -116,6 +113,10 @@ func (esp *esdtSuppliesProcessor) getShardSupply(token string, shardID uint32) (
 		}
 
 		log.Info("network metrics request", "shard ID", observer.ShardId, "observer", observer.Address)
+
+		if responseEsdtSupply.Data.Supply == "" {
+			return big.NewInt(0), nil
+		}
 
 		bigValue, _ := big.NewInt(0).SetString(responseEsdtSupply.Data.Supply, 10)
 		return bigValue, nil

--- a/process/esdtSuppliesProcessor.go
+++ b/process/esdtSuppliesProcessor.go
@@ -107,11 +107,11 @@ func (esp *esdtSuppliesProcessor) getShardSupply(token string, shardID uint32) (
 
 	apiPath := networkESDTSupplyPath + token
 	for _, observer := range shardObservers {
-		var responseEsdtSupply *data.ESDTSupplyResponse
+		var responseEsdtSupply data.ESDTSupplyResponse
 
 		_, errGet := esp.baseProc.CallGetRestEndPoint(observer.Address, apiPath, &responseEsdtSupply)
 		if errGet != nil {
-			log.Error("network metrics request", "observer", observer.Address, "error", errGet.Error())
+			log.Error("esdt supply request", "observer", observer.Address, "error", errGet.Error())
 			continue
 		}
 

--- a/process/esdtSuppliesProcessor_test.go
+++ b/process/esdtSuppliesProcessor_test.go
@@ -95,7 +95,7 @@ func TestEsdtSuppliesProcessor_GetESDTSupplyNonFungible(t *testing.T) {
 					return 400, errors.New("local err")
 				}
 				valResp := value.(*data.ESDTSupplyResponse)
-				valResp.Data.Supply = "1000"
+				valResp.Data.Supply = "-1000"
 				return 200, nil
 			case "shard-1":
 				valResp := value.(*data.ESDTSupplyResponse)
@@ -111,5 +111,5 @@ func TestEsdtSuppliesProcessor_GetESDTSupplyNonFungible(t *testing.T) {
 
 	supplyRes, err := esdtProc.GetESDTSupply("SEMI-ABCD-0A")
 	require.Nil(t, err)
-	require.Equal(t, "4000", supplyRes.Data.Supply)
+	require.Equal(t, "2000", supplyRes.Data.Supply)
 }

--- a/process/esdtSuppliesProcessor_test.go
+++ b/process/esdtSuppliesProcessor_test.go
@@ -1,0 +1,115 @@
+package process
+
+import (
+	"errors"
+	"fmt"
+	"math/big"
+	"testing"
+
+	"github.com/ElrondNetwork/elrond-go/core"
+	"github.com/ElrondNetwork/elrond-go/data/vm"
+	"github.com/ElrondNetwork/elrond-proxy-go/data"
+	"github.com/ElrondNetwork/elrond-proxy-go/process/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewESDTSuppliesProcessor(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewESDTSuppliesProcessor(nil, &mock.SCQueryServiceStub{})
+	require.Equal(t, ErrNilCoreProcessor, err)
+
+	_, err = NewESDTSuppliesProcessor(&mock.ProcessorStub{}, nil)
+	require.Equal(t, ErrNilSCQueryService, err)
+}
+
+func TestEsdtSuppliesProcessor_GetESDTSupplyFungible(t *testing.T) {
+	t.Parallel()
+
+	baseProc := &mock.ProcessorStub{
+		GetShardIDsCalled: func() []uint32 {
+			return []uint32{0, 1, core.MetachainShardId}
+		},
+		GetObserversCalled: func(shardID uint32) ([]*data.NodeData, error) {
+			return []*data.NodeData{
+				{
+					ShardId: shardID,
+					Address: fmt.Sprintf("shard-%d", shardID),
+				},
+			}, nil
+		},
+		CallGetRestEndPointCalled: func(address string, path string, value interface{}) (int, error) {
+			switch address {
+			case "shard-0":
+				valResp := value.(*data.ESDTSupplyResponse)
+				valResp.Data.Supply = "1000"
+				return 200, nil
+			case "shard-1":
+				valResp := value.(*data.ESDTSupplyResponse)
+				valResp.Data.Supply = "3000"
+				return 200, nil
+			}
+			return 0, nil
+		},
+	}
+	scQueryProc := &mock.SCQueryServiceStub{
+		ExecuteQueryCalled: func(query *data.SCQuery) (*vm.VMOutputApi, error) {
+			return &vm.VMOutputApi{
+				ReturnData: [][]byte{nil, nil, nil, big.NewInt(500).Bytes()},
+			}, nil
+		},
+	}
+	esdtProc, err := NewESDTSuppliesProcessor(baseProc, scQueryProc)
+	require.Nil(t, err)
+
+	supplyRes, err := esdtProc.GetESDTSupply("TOKEN-ABCD")
+	require.Nil(t, err)
+	require.Equal(t, "4500", supplyRes.Data.Supply)
+}
+
+func TestEsdtSuppliesProcessor_GetESDTSupplyNonFungible(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	baseProc := &mock.ProcessorStub{
+		GetShardIDsCalled: func() []uint32 {
+			return []uint32{0, 1, core.MetachainShardId}
+		},
+		GetObserversCalled: func(shardID uint32) ([]*data.NodeData, error) {
+			return []*data.NodeData{
+				{
+					ShardId: shardID,
+					Address: fmt.Sprintf("shard-%d", shardID),
+				},
+				{
+					ShardId: shardID,
+					Address: fmt.Sprintf("shard-%d", shardID),
+				},
+			}, nil
+		},
+		CallGetRestEndPointCalled: func(address string, path string, value interface{}) (int, error) {
+			switch address {
+			case "shard-0":
+				if !called {
+					called = true
+					return 400, errors.New("local err")
+				}
+				valResp := value.(*data.ESDTSupplyResponse)
+				valResp.Data.Supply = "1000"
+				return 200, nil
+			case "shard-1":
+				valResp := value.(*data.ESDTSupplyResponse)
+				valResp.Data.Supply = "3000"
+				return 200, nil
+			}
+			return 0, nil
+		},
+	}
+	scQueryProc := &mock.SCQueryServiceStub{}
+	esdtProc, err := NewESDTSuppliesProcessor(baseProc, scQueryProc)
+	require.Nil(t, err)
+
+	supplyRes, err := esdtProc.GetESDTSupply("SEMI-ABCD-0A")
+	require.Nil(t, err)
+	require.Equal(t, "4000", supplyRes.Data.Supply)
+}

--- a/process/esdtSuppliesProcessor_test.go
+++ b/process/esdtSuppliesProcessor_test.go
@@ -3,7 +3,6 @@ package process
 import (
 	"errors"
 	"fmt"
-	"math/big"
 	"testing"
 
 	"github.com/ElrondNetwork/elrond-go/core"
@@ -55,7 +54,7 @@ func TestEsdtSuppliesProcessor_GetESDTSupplyFungible(t *testing.T) {
 	scQueryProc := &mock.SCQueryServiceStub{
 		ExecuteQueryCalled: func(query *data.SCQuery) (*vm.VMOutputApi, error) {
 			return &vm.VMOutputApi{
-				ReturnData: [][]byte{nil, nil, nil, big.NewInt(500).Bytes()},
+				ReturnData: [][]byte{nil, nil, nil, []byte("500")},
 			}, nil
 		},
 	}

--- a/process/esdtSupplyProcessor_test.go
+++ b/process/esdtSupplyProcessor_test.go
@@ -12,17 +12,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestNewESDTSuppliesProcessor(t *testing.T) {
+func TestNewESDTSupplyProcessor(t *testing.T) {
 	t.Parallel()
 
-	_, err := NewESDTSuppliesProcessor(nil, &mock.SCQueryServiceStub{})
+	_, err := NewESDTSupplyProcessor(nil, &mock.SCQueryServiceStub{})
 	require.Equal(t, ErrNilCoreProcessor, err)
 
-	_, err = NewESDTSuppliesProcessor(&mock.ProcessorStub{}, nil)
+	_, err = NewESDTSupplyProcessor(&mock.ProcessorStub{}, nil)
 	require.Equal(t, ErrNilSCQueryService, err)
 }
 
-func TestEsdtSuppliesProcessor_GetESDTSupplyFungible(t *testing.T) {
+func TestEsdtSupplyProcessor_GetESDTSupplyFungible(t *testing.T) {
 	t.Parallel()
 
 	baseProc := &mock.ProcessorStub{
@@ -58,7 +58,7 @@ func TestEsdtSuppliesProcessor_GetESDTSupplyFungible(t *testing.T) {
 			}, nil
 		},
 	}
-	esdtProc, err := NewESDTSuppliesProcessor(baseProc, scQueryProc)
+	esdtProc, err := NewESDTSupplyProcessor(baseProc, scQueryProc)
 	require.Nil(t, err)
 
 	supplyRes, err := esdtProc.GetESDTSupply("TOKEN-ABCD")
@@ -66,7 +66,7 @@ func TestEsdtSuppliesProcessor_GetESDTSupplyFungible(t *testing.T) {
 	require.Equal(t, "4500", supplyRes.Data.Supply)
 }
 
-func TestEsdtSuppliesProcessor_GetESDTSupplyNonFungible(t *testing.T) {
+func TestEsdtSupplyProcessor_GetESDTSupplyNonFungible(t *testing.T) {
 	t.Parallel()
 
 	called := false
@@ -105,7 +105,7 @@ func TestEsdtSuppliesProcessor_GetESDTSupplyNonFungible(t *testing.T) {
 		},
 	}
 	scQueryProc := &mock.SCQueryServiceStub{}
-	esdtProc, err := NewESDTSuppliesProcessor(baseProc, scQueryProc)
+	esdtProc, err := NewESDTSupplyProcessor(baseProc, scQueryProc)
 	require.Nil(t, err)
 
 	supplyRes, err := esdtProc.GetESDTSupply("SEMI-ABCD-0A")

--- a/process/interface.go
+++ b/process/interface.go
@@ -76,4 +76,5 @@ type LogsMergerHandler interface {
 // SCQueryService defines how data should be get from a SC account
 type SCQueryService interface {
 	ExecuteQuery(query *data.SCQuery) (*vm.VMOutputApi, error)
+	IsInterfaceNil() bool
 }

--- a/process/interface.go
+++ b/process/interface.go
@@ -4,6 +4,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/core"
 	"github.com/ElrondNetwork/elrond-go/crypto"
 	"github.com/ElrondNetwork/elrond-go/data/transaction"
+	"github.com/ElrondNetwork/elrond-go/data/vm"
 	"github.com/ElrondNetwork/elrond-go/sharding"
 	"github.com/ElrondNetwork/elrond-proxy-go/data"
 	"github.com/ElrondNetwork/elrond-proxy-go/observer"
@@ -70,4 +71,9 @@ type TransactionCostHandler interface {
 type LogsMergerHandler interface {
 	MergeLogEvents(logSource *transaction.ApiLogs, logDestination *transaction.ApiLogs) *transaction.ApiLogs
 	IsInterfaceNil() bool
+}
+
+// SCQueryService defines how data should be get from a SC account
+type SCQueryService interface {
+	ExecuteQuery(query *data.SCQuery) (*vm.VMOutputApi, error)
 }

--- a/process/mock/scQueryServiceStub.go
+++ b/process/mock/scQueryServiceStub.go
@@ -14,3 +14,8 @@ type SCQueryServiceStub struct {
 func (serviceStub *SCQueryServiceStub) ExecuteQuery(query *data.SCQuery) (*vm.VMOutputApi, error) {
 	return serviceStub.ExecuteQueryCalled(query)
 }
+
+// IsInterfaceNil returns true if the value under the interface is nil
+func (serviceStub *SCQueryServiceStub) IsInterfaceNil() bool {
+	return serviceStub == nil
+}

--- a/process/mock/scQueryServiceStub.go
+++ b/process/mock/scQueryServiceStub.go
@@ -1,0 +1,16 @@
+package mock
+
+import (
+	"github.com/ElrondNetwork/elrond-go/data/vm"
+	"github.com/ElrondNetwork/elrond-proxy-go/data"
+)
+
+// SCQueryServiceStub is a stub
+type SCQueryServiceStub struct {
+	ExecuteQueryCalled func(*data.SCQuery) (*vm.VMOutputApi, error)
+}
+
+// ExecuteQuery is a stub
+func (serviceStub *SCQueryServiceStub) ExecuteQuery(query *data.SCQuery) (*vm.VMOutputApi, error) {
+	return serviceStub.ExecuteQueryCalled(query)
+}

--- a/process/nodeStatusProcessor.go
+++ b/process/nodeStatusProcessor.go
@@ -20,7 +20,7 @@ const (
 	// NetworkConfigPath represents the path where an observer exposes his network metrics
 	NetworkConfigPath = "/network/config"
 
-	// NetworkConfigPath represents the path where an observer exposes his node status metrics
+	// NodeStatusPath represents the path where an observer exposes his node status metrics
 	NodeStatusPath = "/node/status"
 
 	// AllIssuedESDTsPath represents the path where an observer exposes all the issued ESDTs
@@ -196,7 +196,7 @@ func (nsp *NodeStatusProcessor) GetDelegatedInfo() (*data.GenericAPIResponse, er
 	return nil, ErrSendingRequest
 }
 
-// GetDelegatedInfo returns the delegated info from nodes
+// GetDirectStakedInfo returns the delegated info from nodes
 func (nsp *NodeStatusProcessor) GetDirectStakedInfo() (*data.GenericAPIResponse, error) {
 	observers, err := nsp.proc.GetObservers(core.MetachainShardId)
 	if err != nil {

--- a/process/scQueryProcessor.go
+++ b/process/scQueryProcessor.go
@@ -95,3 +95,8 @@ func (scQueryProcessor *SCQueryProcessor) createRequestFromQuery(query *data.SCQ
 
 	return request
 }
+
+// IsInterfaceNil returns true if the value under the interface is nil
+func (scQueryProcessor *SCQueryProcessor) IsInterfaceNil() bool {
+	return scQueryProcessor == nil
+}

--- a/versions/factory/versionedFacadeCreator.go
+++ b/versions/factory/versionedFacadeCreator.go
@@ -25,7 +25,7 @@ type FacadeArgs struct {
 	ValidatorStatisticsProcessor facade.ValidatorStatisticsProcessor
 	ProofProcessor               facade.ProofProcessor
 	PubKeyConverter              core.PubkeyConverter
-	ESDTSuppliesProcessor        facade.ESDTSuppliesProcessor
+	ESDTSuppliesProcessor        facade.ESDTSupplyProcessor
 }
 
 // CreateVersionsRegistry creates the version registry instances and populates it with the versions and their handlers

--- a/versions/factory/versionedFacadeCreator.go
+++ b/versions/factory/versionedFacadeCreator.go
@@ -25,6 +25,7 @@ type FacadeArgs struct {
 	ValidatorStatisticsProcessor facade.ValidatorStatisticsProcessor
 	ProofProcessor               facade.ProofProcessor
 	PubKeyConverter              core.PubkeyConverter
+	ESDTSuppliesProcessor        facade.ESDTSuppliesProcessor
 }
 
 // CreateVersionsRegistry creates the version registry instances and populates it with the versions and their handlers
@@ -43,10 +44,10 @@ func CreateVersionsRegistry(facadeArgs FacadeArgs, apiConfigParser ApiConfigPars
 
 	// un-comment these lines if you want to start proxy also with the v_next
 
-	//err = addVersionV_next(facadeArgs, versionsRegistry)
-	//if err != nil {
+	// err = addVersionV_next(facadeArgs, versionsRegistry)
+	// if err != nil {
 	//	return nil, err
-	//}
+	// }
 
 	return versionsRegistry, nil
 }
@@ -193,5 +194,6 @@ func createVersionedFacade(args FacadeArgs) (data.FacadeHandler, error) {
 		args.BlockProcessor,
 		args.ProofProcessor,
 		args.PubKeyConverter,
+		args.ESDTSuppliesProcessor,
 	)
 }

--- a/versions/factory/versionedFacadeCreator.go
+++ b/versions/factory/versionedFacadeCreator.go
@@ -104,6 +104,7 @@ func createVersionV1_0Facade(facadeArgs FacadeArgs) (*facadeVersions.ElrondProxy
 		ValidatorStatisticsProcessor: facadeArgs.ValidatorStatisticsProcessor,
 		ProofProcessor:               facadeArgs.ProofProcessor,
 		PubKeyConverter:              facadeArgs.PubKeyConverter,
+		ESDTSuppliesProcessor:        facadeArgs.ESDTSuppliesProcessor,
 	}
 
 	commonFacade, err := createVersionedFacade(v1_0HandlerArgs)
@@ -159,6 +160,7 @@ func createVersionV_nextFacade(facadeArgs FacadeArgs) (data.FacadeHandler, error
 		TransactionProcessor:         facadeArgs.TransactionProcessor,
 		ValidatorStatisticsProcessor: facadeArgs.ValidatorStatisticsProcessor,
 		PubKeyConverter:              facadeArgs.PubKeyConverter,
+		ESDTSuppliesProcessor:        facadeArgs.ESDTSuppliesProcessor,
 	}
 
 	commonFacade, err := createVersionedFacade(v_nextHandlerArgs)


### PR DESCRIPTION
Added a new API route `/network/esdt/supply/:token` that will return the total supply of the provided token.