### PR TITLE
EN-11443: add proxy metrics

### DIFF
--- a/api/apiHandler.go
+++ b/api/apiHandler.go
@@ -69,6 +69,11 @@ func initBaseGroupsWithFacade(facade data.FacadeHandler) (map[string]data.GroupH
 		return nil, err
 	}
 
+	statusGroup, err := groups.NewStatusGroup(facade)
+	if err != nil {
+		return nil, err
+	}
+
 	transactionsGroup, err := groups.NewTransactionGroup(facade)
 	if err != nil {
 		return nil, err
@@ -98,6 +103,7 @@ func initBaseGroupsWithFacade(facade data.FacadeHandler) (map[string]data.GroupH
 		"/hyperblock":  hyperBlocksGroup,
 		"/network":     networkGroup,
 		"/node":        nodeGroup,
+		"/status":      statusGroup,
 		"/transaction": transactionsGroup,
 		"/validator":   validatorsGroup,
 		"/vm-values":   vmValuesGroup,

--- a/api/groups/baseGroup.go
+++ b/api/groups/baseGroup.go
@@ -84,6 +84,7 @@ func (bg *baseGroup) RegisterRoutes(
 	apiConfig data.ApiRoutesConfig,
 	authenticationFunc gin.HandlerFunc,
 	rateLimiter gin.HandlerFunc,
+	statusMetricsExtractor gin.HandlerFunc,
 ) {
 	bg.RLock()
 	defer bg.RUnlock()
@@ -110,6 +111,7 @@ func (bg *baseGroup) RegisterRoutes(
 			middlewares = append(middlewares, rateLimiter)
 		}
 
+		middlewares = append(middlewares, statusMetricsExtractor)
 		middlewares = append(middlewares, handlerData.Handler)
 
 		ws.Handle(handlerData.Method, handlerData.Path, middlewares...)

--- a/api/groups/baseStatusGroup.go
+++ b/api/groups/baseStatusGroup.go
@@ -1,0 +1,45 @@
+package groups
+
+import (
+	"net/http"
+
+	"github.com/ElrondNetwork/elrond-proxy-go/api/shared"
+	"github.com/ElrondNetwork/elrond-proxy-go/data"
+	"github.com/gin-gonic/gin"
+)
+
+type statusGroup struct {
+	facade StatusFacadeHandler
+	*baseGroup
+}
+
+// NewStatusGroup returns a new instance of statusGroup
+func NewStatusGroup(facadeHandler data.FacadeHandler) (*statusGroup, error) {
+	facade, ok := facadeHandler.(StatusFacadeHandler)
+	if !ok {
+		return nil, ErrWrongTypeAssertion
+	}
+
+	ng := &statusGroup{
+		facade:    facade,
+		baseGroup: &baseGroup{},
+	}
+
+	baseRoutesHandlers := []*data.EndpointHandlerData{
+		{Path: "/metrics", Handler: ng.getMetrics, Method: http.MethodGet},
+	}
+	ng.baseGroup.endpoints = baseRoutesHandlers
+
+	return ng, nil
+}
+
+// getHeartbeatData will expose heartbeat status from an observer (if any available) in json format
+func (group *statusGroup) getMetrics(c *gin.Context) {
+	metricsResults, err := group.facade.GetMetrics()
+	if err != nil {
+		shared.RespondWith(c, http.StatusInternalServerError, nil, err.Error(), data.ReturnCodeInternalError)
+		return
+	}
+
+	shared.RespondWith(c, http.StatusOK, gin.H{"metrics": metricsResults}, "", data.ReturnCodeSuccess)
+}

--- a/api/groups/baseStatusGroup.go
+++ b/api/groups/baseStatusGroup.go
@@ -27,19 +27,23 @@ func NewStatusGroup(facadeHandler data.FacadeHandler) (*statusGroup, error) {
 
 	baseRoutesHandlers := []*data.EndpointHandlerData{
 		{Path: "/metrics", Handler: ng.getMetrics, Method: http.MethodGet},
+		{Path: "/prometheus-metrics", Handler: ng.getPrometheusMetrics, Method: http.MethodGet},
 	}
 	ng.baseGroup.endpoints = baseRoutesHandlers
 
 	return ng, nil
 }
 
-// getHeartbeatData will expose heartbeat status from an observer (if any available) in json format
+// getMetrics will expose endpoints statistics in json format
 func (group *statusGroup) getMetrics(c *gin.Context) {
-	metricsResults, err := group.facade.GetMetrics()
-	if err != nil {
-		shared.RespondWith(c, http.StatusInternalServerError, nil, err.Error(), data.ReturnCodeInternalError)
-		return
-	}
+	metricsResults := group.facade.GetMetrics()
 
 	shared.RespondWith(c, http.StatusOK, gin.H{"metrics": metricsResults}, "", data.ReturnCodeSuccess)
+}
+
+// getPrometheusMetrics will expose proxy metrics in prometheus format
+func (group *statusGroup) getPrometheusMetrics(c *gin.Context) {
+	metricsResults := group.facade.GetMetricsForPrometheus()
+
+	c.String(http.StatusOK, metricsResults)
 }

--- a/api/groups/baseStatusGroup_test.go
+++ b/api/groups/baseStatusGroup_test.go
@@ -1,0 +1,89 @@
+package groups_test
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ElrondNetwork/elrond-proxy-go/api/groups"
+	"github.com/ElrondNetwork/elrond-proxy-go/api/mock"
+	"github.com/ElrondNetwork/elrond-proxy-go/data"
+	"github.com/stretchr/testify/require"
+)
+
+type statusMetricsResponse struct {
+	Data struct {
+		Metrics map[string]*data.EndpointMetrics `json:"metrics"`
+	}
+	Error string `json:"error"`
+	Code  string `json:"code"`
+}
+
+const statusPath = "/status"
+
+func TestNewStatusGroup_WrongFacadeShouldErr(t *testing.T) {
+	t.Parallel()
+
+	wrongFacade := &mock.WrongFacade{}
+	group, err := groups.NewStatusGroup(wrongFacade)
+	require.Nil(t, group)
+	require.Equal(t, groups.ErrWrongTypeAssertion, err)
+}
+
+func TestGetMetrics_ShouldErrorIfFacadeReturnsError(t *testing.T) {
+	t.Parallel()
+
+	expectedErr := errors.New("error")
+	facade := &mock.Facade{
+		GetMetricsCalled: func() (map[string]*data.EndpointMetrics, error) {
+			return nil, expectedErr
+		},
+	}
+
+	statusGroup, err := groups.NewStatusGroup(facade)
+	require.NoError(t, err)
+	ws := startProxyServer(statusGroup, statusPath)
+
+	req, _ := http.NewRequest("GET", "/status/metrics", nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	var apiResp data.GenericAPIResponse
+	loadResponse(resp.Body, &apiResp)
+	require.Equal(t, http.StatusInternalServerError, resp.Code)
+	require.Equal(t, expectedErr.Error(), apiResp.Error)
+}
+
+func TestGetMetrics_ShouldWork(t *testing.T) {
+	t.Parallel()
+
+	expectedMetrics := map[string]*data.EndpointMetrics{
+		"/network/config": {
+			NumRequests:         5,
+			NumErrors:           3,
+			TotalResponseTime:   100,
+			LowestResponseTime:  20,
+			HighestResponseTime: 50,
+		},
+	}
+	facade := &mock.Facade{
+		GetMetricsCalled: func() (map[string]*data.EndpointMetrics, error) {
+			return expectedMetrics, nil
+		},
+	}
+
+	statusGroup, err := groups.NewStatusGroup(facade)
+	require.NoError(t, err)
+	ws := startProxyServer(statusGroup, statusPath)
+
+	req, _ := http.NewRequest("GET", "/status/metrics", nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	var apiResp statusMetricsResponse
+	loadResponse(resp.Body, &apiResp)
+	require.Equal(t, http.StatusOK, resp.Code)
+
+	require.Equal(t, expectedMetrics, apiResp.Data.Metrics)
+}

--- a/api/groups/common_test.go
+++ b/api/groups/common_test.go
@@ -18,7 +18,7 @@ func startProxyServer(group data.GroupHandler, path string) *gin.Engine {
 	ws := gin.New()
 	ws.Use(cors.Default())
 	routes := ws.Group(path)
-	group.RegisterRoutes(routes, data.ApiRoutesConfig{}, func(_ *gin.Context) {}, func(_ *gin.Context) {})
+	group.RegisterRoutes(routes, data.ApiRoutesConfig{}, func(_ *gin.Context) {}, func(_ *gin.Context) {}, func(_ *gin.Context) {})
 	return ws
 }
 

--- a/api/groups/common_test.go
+++ b/api/groups/common_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+var emptyGinHandler = func(_ *gin.Context) {}
+
 func init() {
 	gin.SetMode(gin.TestMode)
 }
@@ -18,7 +20,7 @@ func startProxyServer(group data.GroupHandler, path string) *gin.Engine {
 	ws := gin.New()
 	ws.Use(cors.Default())
 	routes := ws.Group(path)
-	group.RegisterRoutes(routes, data.ApiRoutesConfig{}, func(_ *gin.Context) {}, func(_ *gin.Context) {}, func(_ *gin.Context) {})
+	group.RegisterRoutes(routes, data.ApiRoutesConfig{}, emptyGinHandler, emptyGinHandler, emptyGinHandler)
 	return ws
 }
 

--- a/api/groups/interface.go
+++ b/api/groups/interface.go
@@ -63,7 +63,8 @@ type NodeFacadeHandler interface {
 
 // StatusFacadeHandler interface defines methods that can be used from the facade
 type StatusFacadeHandler interface {
-	GetMetrics() (map[string]*data.EndpointMetrics, error)
+	GetMetrics() map[string]*data.EndpointMetrics
+	GetMetricsForPrometheus() string
 }
 
 // TransactionFacadeHandler interface defines methods that can be used from the facade

--- a/api/groups/interface.go
+++ b/api/groups/interface.go
@@ -61,6 +61,11 @@ type NodeFacadeHandler interface {
 	GetHeartbeatData() (*data.HeartbeatResponse, error)
 }
 
+// StatusFacadeHandler interface defines methods that can be used from the facade
+type StatusFacadeHandler interface {
+	GetMetrics() (map[string]*data.EndpointMetrics, error)
+}
+
 // TransactionFacadeHandler interface defines methods that can be used from the facade
 type TransactionFacadeHandler interface {
 	SendTransaction(tx *data.Transaction) (int, string, error)

--- a/api/middleware/errors.go
+++ b/api/middleware/errors.go
@@ -4,3 +4,6 @@ import "errors"
 
 // ErrNilLimitsMapForEndpoints signals that a nil limits map has been provided
 var ErrNilLimitsMapForEndpoints = errors.New("nil limits map")
+
+// ErrNilStatusMetricsExtractor signals that a nil status metrics extractor has been provided
+var ErrNilStatusMetricsExtractor = errors.New("nil status metrics extractor")

--- a/api/middleware/interface.go
+++ b/api/middleware/interface.go
@@ -1,9 +1,19 @@
 package middleware
 
-import "github.com/ElrondNetwork/elrond-go/api"
+import (
+	"time"
+
+	"github.com/ElrondNetwork/elrond-go/api"
+)
 
 // RateLimiterHandler defines the actions that an implementation of rate limiter handler should do
 type RateLimiterHandler interface {
 	api.MiddlewareProcessor
 	ResetMap(version string)
+}
+
+// StatusMetricsExtractor defines what a status metrics extractor should do
+type StatusMetricsExtractor interface {
+	AddRequestData(path string, withError bool, duration time.Duration)
+	IsInterfaceNil() bool
 }

--- a/api/middleware/metricsMiddleware.go
+++ b/api/middleware/metricsMiddleware.go
@@ -19,14 +19,14 @@ func NewMetricsMiddleware(statusMetricsExtractor StatusMetricsExtractor) (*metri
 		return nil, ErrNilStatusMetricsExtractor
 	}
 
-	rlm := &metricsMiddleware{
+	mm := &metricsMiddleware{
 		statusMetricsExtractor: statusMetricsExtractor,
 	}
 
-	return rlm, nil
+	return mm, nil
 }
 
-// MonitoringMiddleware logs detail about a request if it is not successful or it's duration is higher than a threshold
+// MiddlewareHandlerFunc logs updated data in regards to endpoints' durations statistics
 func (mm *metricsMiddleware) MiddlewareHandlerFunc() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		t := time.Now()

--- a/api/middleware/metricsMiddleware.go
+++ b/api/middleware/metricsMiddleware.go
@@ -1,0 +1,51 @@
+package middleware
+
+import (
+	"bytes"
+	"net/http"
+	"time"
+
+	"github.com/ElrondNetwork/elrond-go/core/check"
+	"github.com/gin-gonic/gin"
+)
+
+type metricsMiddleware struct {
+	statusMetricsExtractor StatusMetricsExtractor
+}
+
+// NewMetricsMiddleware returns a new instance of metricsMiddleware
+func NewMetricsMiddleware(statusMetricsExtractor StatusMetricsExtractor) (*metricsMiddleware, error) {
+	if check.IfNil(statusMetricsExtractor) {
+		return nil, ErrNilStatusMetricsExtractor
+	}
+
+	rlm := &metricsMiddleware{
+		statusMetricsExtractor: statusMetricsExtractor,
+	}
+
+	return rlm, nil
+}
+
+// MonitoringMiddleware logs detail about a request if it is not successful or it's duration is higher than a threshold
+func (mm *metricsMiddleware) MiddlewareHandlerFunc() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		t := time.Now()
+
+		bw := &bodyWriter{body: bytes.NewBufferString(""), ResponseWriter: c.Writer}
+		c.Writer = bw
+
+		c.Next()
+
+		duration := time.Since(t)
+		status := c.Writer.Status()
+
+		withError := status != http.StatusOK
+
+		mm.statusMetricsExtractor.AddRequestData(c.FullPath(), withError, duration)
+	}
+}
+
+// IsInterfaceNil returns true if there is no value under the interface
+func (mm *metricsMiddleware) IsInterfaceNil() bool {
+	return mm == nil
+}

--- a/api/middleware/metricsMiddleware_test.go
+++ b/api/middleware/metricsMiddleware_test.go
@@ -1,0 +1,88 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/ElrondNetwork/elrond-proxy-go/api/groups"
+	apiMock "github.com/ElrondNetwork/elrond-proxy-go/api/mock"
+	"github.com/ElrondNetwork/elrond-proxy-go/data"
+	"github.com/gin-contrib/cors"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func startApiServerMetrics(handler groups.AccountsFacadeHandler, metricsMiddleware *metricsMiddleware) *gin.Engine {
+	ws := gin.New()
+	ws.Use(cors.Default())
+	ws.Use(metricsMiddleware.MiddlewareHandlerFunc())
+	accGr, _ := groups.NewAccountsGroup(handler)
+
+	group := ws.Group("/address")
+	accGr.RegisterRoutes(group, data.ApiRoutesConfig{}, func(_ *gin.Context) {}, func(_ *gin.Context) {}, func(_ *gin.Context) {})
+	return ws
+}
+
+func TestNewMetricsMiddleware(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil status metrics exporter - should err", func(t *testing.T) {
+		t.Parallel()
+
+		mm, err := NewMetricsMiddleware(nil)
+		require.Nil(t, mm)
+		require.Equal(t, ErrNilStatusMetricsExtractor, err)
+	})
+
+	t.Run("should work", func(t *testing.T) {
+		t.Parallel()
+
+		mm, err := NewMetricsMiddleware(&apiMock.StatusMetricsExporterStub{})
+		require.NoError(t, err)
+		require.NotNil(t, mm)
+	})
+}
+
+func TestMetricsMiddleware_MiddlewareHandlerFunc(t *testing.T) {
+	t.Parallel()
+
+	type receivedRequestData struct {
+		path      string
+		withError bool
+		duration  time.Duration
+	}
+	receivedData := make([]*receivedRequestData, 0)
+	mm, err := NewMetricsMiddleware(&apiMock.StatusMetricsExporterStub{
+		AddRequestDataCalled: func(path string, withError bool, duration time.Duration) {
+			receivedData = append(receivedData, &receivedRequestData{
+				path:      path,
+				withError: withError,
+				duration:  duration,
+			})
+		},
+	})
+	require.NoError(t, err)
+
+	facade := &apiMock.Facade{
+		GetAccountHandler: func(address string) (*data.Account, error) {
+			return &data.Account{
+				Address: address,
+				Nonce:   1,
+				Balance: "100",
+			}, nil
+		},
+	}
+
+	ws := startApiServerMetrics(facade, mm)
+
+	resp := httptest.NewRecorder()
+	context, _ := gin.CreateTestContext(resp)
+	req, _ := http.NewRequestWithContext(context, "GET", "/address/test", nil)
+	ws.ServeHTTP(resp, req)
+
+	require.Len(t, receivedData, 1)
+	require.Equal(t, "/address/:address", receivedData[0].path)
+	require.False(t, receivedData[0].withError)
+}

--- a/api/middleware/metricsMiddleware_test.go
+++ b/api/middleware/metricsMiddleware_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var emptyGinHandler = func(_ *gin.Context) {}
+
 func startApiServerMetrics(handler groups.AccountsFacadeHandler, metricsMiddleware *metricsMiddleware) *gin.Engine {
 	ws := gin.New()
 	ws.Use(cors.Default())
@@ -21,7 +23,7 @@ func startApiServerMetrics(handler groups.AccountsFacadeHandler, metricsMiddlewa
 	accGr, _ := groups.NewAccountsGroup(handler)
 
 	group := ws.Group("/address")
-	accGr.RegisterRoutes(group, data.ApiRoutesConfig{}, func(_ *gin.Context) {}, func(_ *gin.Context) {}, func(_ *gin.Context) {})
+	accGr.RegisterRoutes(group, data.ApiRoutesConfig{}, emptyGinHandler, emptyGinHandler, emptyGinHandler)
 	return ws
 }
 

--- a/api/middleware/rateLimiter_test.go
+++ b/api/middleware/rateLimiter_test.go
@@ -126,6 +126,6 @@ func startProxyServer(group data.GroupHandler, rateLimiter RateLimiterHandler, r
 			},
 		},
 	}
-	group.RegisterRoutes(routes, apiConfig, func(_ *gin.Context) {}, rateLimiter.MiddlewareHandlerFunc())
+	group.RegisterRoutes(routes, apiConfig, func(_ *gin.Context) {}, rateLimiter.MiddlewareHandlerFunc(), func(_ *gin.Context) {})
 	return ws
 }

--- a/api/middleware/rateLimiter_test.go
+++ b/api/middleware/rateLimiter_test.go
@@ -126,6 +126,6 @@ func startProxyServer(group data.GroupHandler, rateLimiter RateLimiterHandler, r
 			},
 		},
 	}
-	group.RegisterRoutes(routes, apiConfig, func(_ *gin.Context) {}, rateLimiter.MiddlewareHandlerFunc(), func(_ *gin.Context) {})
+	group.RegisterRoutes(routes, apiConfig, emptyGinHandler, rateLimiter.MiddlewareHandlerFunc(), emptyGinHandler)
 	return ws
 }

--- a/api/middleware/responseLogger.go
+++ b/api/middleware/responseLogger.go
@@ -37,7 +37,7 @@ func NewResponseLoggerMiddleware(thresholdDurationForLoggingRequest time.Duratio
 	return rlm
 }
 
-// MonitoringMiddleware logs detail about a request if it is not successful or it's duration is higher than a threshold
+// MiddlewareHandlerFunc logs detail about a request if it is not successful or it's duration is higher than a threshold
 func (rlm *responseLoggerMiddleware) MiddlewareHandlerFunc() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		t := time.Now()

--- a/api/middleware/responseLogger_test.go
+++ b/api/middleware/responseLogger_test.go
@@ -25,7 +25,7 @@ func startApiServerResponseLogger(handler groups.AccountsFacadeHandler, respLogM
 	accGr, _ := groups.NewAccountsGroup(handler)
 
 	group := ws.Group("/address")
-	accGr.RegisterRoutes(group, data.ApiRoutesConfig{}, func(_ *gin.Context) {}, func(_ *gin.Context) {})
+	accGr.RegisterRoutes(group, data.ApiRoutesConfig{}, func(_ *gin.Context) {}, func(_ *gin.Context) {}, func(_ *gin.Context) {})
 	return ws
 }
 

--- a/api/middleware/responseLogger_test.go
+++ b/api/middleware/responseLogger_test.go
@@ -25,7 +25,7 @@ func startApiServerResponseLogger(handler groups.AccountsFacadeHandler, respLogM
 	accGr, _ := groups.NewAccountsGroup(handler)
 
 	group := ws.Group("/address")
-	accGr.RegisterRoutes(group, data.ApiRoutesConfig{}, func(_ *gin.Context) {}, func(_ *gin.Context) {}, func(_ *gin.Context) {})
+	accGr.RegisterRoutes(group, data.ApiRoutesConfig{}, emptyGinHandler, emptyGinHandler, emptyGinHandler)
 	return ws
 }
 

--- a/api/mock/facade.go
+++ b/api/mock/facade.go
@@ -52,7 +52,8 @@ type Facade struct {
 	VerifyProofCalled                           func(string, string, []string) (*data.GenericAPIResponse, error)
 	GetESDTsRolesCalled                         func(address string) (*data.GenericAPIResponse, error)
 	GetESDTSupplyCalled                         func(token string) (*data.ESDTSupplyResponse, error)
-	GetMetricsCalled                            func() (map[string]*data.EndpointMetrics, error)
+	GetMetricsCalled                            func() map[string]*data.EndpointMetrics
+	GetPrometheusMetricsCalled                  func() string
 }
 
 // GetProof -
@@ -350,8 +351,13 @@ func (f *Facade) GetHyperBlockByNonce(nonce uint64) (*data.HyperblockApiResponse
 }
 
 // GetMetrics -
-func (f *Facade) GetMetrics() (map[string]*data.EndpointMetrics, error) {
+func (f *Facade) GetMetrics() map[string]*data.EndpointMetrics {
 	return f.GetMetricsCalled()
+}
+
+// GetMetricsForPrometheus -
+func (f *Facade) GetMetricsForPrometheus() string {
+	return f.GetPrometheusMetricsCalled()
 }
 
 // WrongFacade is a struct that can be used as a wrong implementation of the node router handler

--- a/api/mock/facade.go
+++ b/api/mock/facade.go
@@ -52,6 +52,7 @@ type Facade struct {
 	VerifyProofCalled                           func(string, string, []string) (*data.GenericAPIResponse, error)
 	GetESDTsRolesCalled                         func(address string) (*data.GenericAPIResponse, error)
 	GetESDTSupplyCalled                         func(token string) (*data.ESDTSupplyResponse, error)
+	GetMetricsCalled                            func() (map[string]*data.EndpointMetrics, error)
 }
 
 // GetProof -
@@ -346,6 +347,11 @@ func (f *Facade) GetHyperBlockByHash(hash string) (*data.HyperblockApiResponse, 
 // GetHyperBlockByNonce -
 func (f *Facade) GetHyperBlockByNonce(nonce uint64) (*data.HyperblockApiResponse, error) {
 	return f.GetHyperBlockByNonceCalled(nonce)
+}
+
+// GetMetrics -
+func (f *Facade) GetMetrics() (map[string]*data.EndpointMetrics, error) {
+	return f.GetMetricsCalled()
 }
 
 // WrongFacade is a struct that can be used as a wrong implementation of the node router handler

--- a/api/mock/statusMetricsExtractor.go
+++ b/api/mock/statusMetricsExtractor.go
@@ -1,0 +1,22 @@
+package mock
+
+import (
+	"time"
+)
+
+// StatusMetricsExporterStub -
+type StatusMetricsExporterStub struct {
+	AddRequestDataCalled func(path string, withError bool, duration time.Duration)
+}
+
+// AddRequestData -
+func (s *StatusMetricsExporterStub) AddRequestData(path string, withError bool, duration time.Duration) {
+	if s.AddRequestDataCalled != nil {
+		s.AddRequestDataCalled(path, withError, duration)
+	}
+}
+
+// IsInterfaceNil -
+func (s *StatusMetricsExporterStub) IsInterfaceNil() bool {
+	return s == nil
+}

--- a/cmd/proxy/config/apiConfig/v1_0.toml
+++ b/cmd/proxy/config/apiConfig/v1_0.toml
@@ -105,3 +105,9 @@ Routes = [
     { Name = "/address/:address", Secured = false, Open = false, RateLimit = 0 },
     { Name = "/verify", Secured = false, Open = false, RateLimit = 0 }
 ]
+
+[APIPackages.status]
+Routes = [
+    { Name = "/metrics", Secured = false, Open = true, RateLimit = 0 },
+    { Name = "/prometheus-metrics", Secured = false, Open = true, RateLimit = 0 }
+]

--- a/cmd/proxy/config/apiConfig/v_next.toml
+++ b/cmd/proxy/config/apiConfig/v_next.toml
@@ -105,3 +105,9 @@ Routes = [
     { Name = "/address/:address", Secured = false, Open = false, RateLimit = 0 },
     { Name = "/verify", Secured = false, Open = false, RateLimit = 0 }
 ]
+
+[APIPackages.status]
+Routes = [
+    { Name = "/metrics", Secured = false, Open = false, RateLimit = 0 },
+    { Name = "/prometheus-metrics", Secured = false, Open = false, RateLimit = 0 }
+]

--- a/data/api.go
+++ b/data/api.go
@@ -74,6 +74,7 @@ type VersionsRegistryHandler interface {
 // StatusMetricsProvider defines what a status metrics provider should do
 type StatusMetricsProvider interface {
 	GetAll() map[string]*EndpointMetrics
+	GetMetricsForPrometheus() string
 	AddRequestData(path string, withError bool, duration time.Duration)
 	IsInterfaceNil() bool
 }

--- a/data/api.go
+++ b/data/api.go
@@ -1,6 +1,8 @@
 package data
 
 import (
+	"time"
+
 	"github.com/gin-gonic/gin"
 )
 
@@ -43,7 +45,7 @@ type EndpointHandlerData struct {
 type GroupHandler interface {
 	AddEndpoint(path string, handlerData EndpointHandlerData) error
 	UpdateEndpoint(path string, handlerData EndpointHandlerData) error
-	RegisterRoutes(ws *gin.RouterGroup, apiConfig ApiRoutesConfig, authenticationFunc gin.HandlerFunc, rateLimiter gin.HandlerFunc)
+	RegisterRoutes(ws *gin.RouterGroup, apiConfig ApiRoutesConfig, authenticationFunc gin.HandlerFunc, rateLimiter gin.HandlerFunc, statusMetricExtractor gin.HandlerFunc)
 	RemoveEndpoint(path string) error
 	IsInterfaceNil() bool
 }
@@ -66,6 +68,13 @@ type FacadeHandler interface {
 type VersionsRegistryHandler interface {
 	AddVersion(version string, versionData *VersionData) error
 	GetAllVersions() (map[string]*VersionData, error)
+	IsInterfaceNil() bool
+}
+
+// StatusMetricsProvider defines what a status metrics provider should do
+type StatusMetricsProvider interface {
+	GetAll() map[string]*EndpointMetrics
+	AddRequestData(path string, withError bool, duration time.Duration)
 	IsInterfaceNil() bool
 }
 

--- a/data/metrics.go
+++ b/data/metrics.go
@@ -9,6 +9,3 @@ type EndpointMetrics struct {
 	LowestResponseTime  time.Duration `json:"lowest_response_time"`
 	HighestResponseTime time.Duration `json:"highest_response_time"`
 }
-
-type EndpointMetricsData struct {
-}

--- a/data/metrics.go
+++ b/data/metrics.go
@@ -2,6 +2,7 @@ package data
 
 import "time"
 
+// EndpointMetrics holds statistics about the requests for a specific endpoint
 type EndpointMetrics struct {
 	NumRequests         uint64        `json:"num_requests"`
 	NumErrors           uint64        `json:"num_errors"`

--- a/data/metrics.go
+++ b/data/metrics.go
@@ -1,0 +1,14 @@
+package data
+
+import "time"
+
+type EndpointMetrics struct {
+	NumRequests         uint64        `json:"num_requests"`
+	NumErrors           uint64        `json:"num_errors"`
+	TotalResponseTime   time.Duration `json:"total_response_time"`
+	LowestResponseTime  time.Duration `json:"lowest_response_time"`
+	HighestResponseTime time.Duration `json:"highest_response_time"`
+}
+
+type EndpointMetricsData struct {
+}

--- a/facade/baseFacade.go
+++ b/facade/baseFacade.go
@@ -410,6 +410,11 @@ func (epf *ElrondProxyFacade) VerifyProof(rootHash string, address string, proof
 }
 
 // GetMetrics will return the status metrics
-func (epf *ElrondProxyFacade) GetMetrics() (map[string]*data.EndpointMetrics, error) {
+func (epf *ElrondProxyFacade) GetMetrics() map[string]*data.EndpointMetrics {
 	return epf.statusProc.GetMetrics()
+}
+
+// GetMetrics will return the status metrics
+func (epf *ElrondProxyFacade) GetMetricsForPrometheus() string {
+	return epf.statusProc.GetMetricsForPrometheus()
 }

--- a/facade/baseFacade.go
+++ b/facade/baseFacade.go
@@ -414,7 +414,7 @@ func (epf *ElrondProxyFacade) GetMetrics() map[string]*data.EndpointMetrics {
 	return epf.statusProc.GetMetrics()
 }
 
-// GetMetrics will return the status metrics
+// GetMetricsForPrometheus will return the status metrics in a prometheus format
 func (epf *ElrondProxyFacade) GetMetricsForPrometheus() string {
 	return epf.statusProc.GetMetricsForPrometheus()
 }

--- a/facade/baseFacade.go
+++ b/facade/baseFacade.go
@@ -38,6 +38,7 @@ type ElrondProxyFacade struct {
 	blocksProc       BlocksProcessor
 	proofProc        ProofProcessor
 	esdtSuppliesProc ESDTSupplyProcessor
+	statusProc       StatusProcessor
 
 	pubKeyConverter core.PubkeyConverter
 }
@@ -57,6 +58,7 @@ func NewElrondProxyFacade(
 	proofProc ProofProcessor,
 	pubKeyConverter core.PubkeyConverter,
 	esdtSuppliesProc ESDTSupplyProcessor,
+	statusProc StatusProcessor,
 ) (*ElrondProxyFacade, error) {
 	if actionsProc == nil {
 		return nil, ErrNilActionsProcessor
@@ -94,6 +96,9 @@ func NewElrondProxyFacade(
 	if esdtSuppliesProc == nil {
 		return nil, ErrNilESDTSuppliesProcessor
 	}
+	if statusProc == nil {
+		return nil, ErrNilStatusProcessor
+	}
 
 	return &ElrondProxyFacade{
 		actionsProc:      actionsProc,
@@ -109,6 +114,7 @@ func NewElrondProxyFacade(
 		proofProc:        proofProc,
 		pubKeyConverter:  pubKeyConverter,
 		esdtSuppliesProc: esdtSuppliesProc,
+		statusProc:       statusProc,
 	}, nil
 }
 
@@ -401,4 +407,9 @@ func (epf *ElrondProxyFacade) GetProofCurrentRootHash(address string) (*data.Gen
 // VerifyProof verifies the given Merkle proof
 func (epf *ElrondProxyFacade) VerifyProof(rootHash string, address string, proof []string) (*data.GenericAPIResponse, error) {
 	return epf.proofProc.VerifyProof(rootHash, address, proof)
+}
+
+// GetMetrics will return the status metrics
+func (epf *ElrondProxyFacade) GetMetrics() (map[string]*data.EndpointMetrics, error) {
+	return epf.statusProc.GetMetrics()
 }

--- a/facade/baseFacade_test.go
+++ b/facade/baseFacade_test.go
@@ -37,6 +37,7 @@ func TestNewElrondProxyFacade_NilActionsProcShouldErr(t *testing.T) {
 		&mock.ProofProcessorStub{},
 		publicKeyConverter,
 		&mock.ESDTSuppliesProcessorStub{},
+		&mock.StatusProcessorStub{},
 	)
 
 	assert.Nil(t, epf)
@@ -60,6 +61,7 @@ func TestNewElrondProxyFacade_NilAccountProcShouldErr(t *testing.T) {
 		&mock.ProofProcessorStub{},
 		publicKeyConverter,
 		&mock.ESDTSuppliesProcessorStub{},
+		&mock.StatusProcessorStub{},
 	)
 
 	assert.Nil(t, epf)
@@ -83,6 +85,7 @@ func TestNewElrondProxyFacade_NilTransactionProcShouldErr(t *testing.T) {
 		&mock.ProofProcessorStub{},
 		publicKeyConverter,
 		&mock.ESDTSuppliesProcessorStub{},
+		&mock.StatusProcessorStub{},
 	)
 
 	assert.Nil(t, epf)
@@ -106,6 +109,7 @@ func TestNewElrondProxyFacade_NilGetValuesProcShouldErr(t *testing.T) {
 		&mock.ProofProcessorStub{},
 		publicKeyConverter,
 		&mock.ESDTSuppliesProcessorStub{},
+		&mock.StatusProcessorStub{},
 	)
 
 	assert.Nil(t, epf)
@@ -129,6 +133,7 @@ func TestNewElrondProxyFacade_NilHeartbeatProcShouldErr(t *testing.T) {
 		&mock.ProofProcessorStub{},
 		publicKeyConverter,
 		&mock.ESDTSuppliesProcessorStub{},
+		&mock.StatusProcessorStub{},
 	)
 
 	assert.Nil(t, epf)
@@ -152,6 +157,7 @@ func TestNewElrondProxyFacade_NilValStatsProcShouldErr(t *testing.T) {
 		&mock.ProofProcessorStub{},
 		publicKeyConverter,
 		&mock.ESDTSuppliesProcessorStub{},
+		&mock.StatusProcessorStub{},
 	)
 
 	assert.Nil(t, epf)
@@ -175,6 +181,7 @@ func TestNewElrondProxyFacade_NilFaucetProcShouldErr(t *testing.T) {
 		&mock.ProofProcessorStub{},
 		publicKeyConverter,
 		&mock.ESDTSuppliesProcessorStub{},
+		&mock.StatusProcessorStub{},
 	)
 
 	assert.Nil(t, epf)
@@ -198,6 +205,7 @@ func TestNewElrondProxyFacade_NilNodeProcessor(t *testing.T) {
 		&mock.ProofProcessorStub{},
 		publicKeyConverter,
 		&mock.ESDTSuppliesProcessorStub{},
+		&mock.StatusProcessorStub{},
 	)
 
 	assert.Nil(t, epf)
@@ -221,6 +229,7 @@ func TestNewElrondProxyFacade_NilBlocksProcessor(t *testing.T) {
 		&mock.ProofProcessorStub{},
 		publicKeyConverter,
 		&mock.ESDTSuppliesProcessorStub{},
+		&mock.StatusProcessorStub{},
 	)
 
 	assert.Nil(t, epf)
@@ -244,10 +253,35 @@ func TestNewElrondProxyFacade_NilProofProcessor(t *testing.T) {
 		nil,
 		publicKeyConverter,
 		&mock.ESDTSuppliesProcessorStub{},
+		&mock.StatusProcessorStub{},
 	)
 
 	assert.Nil(t, epf)
 	assert.Equal(t, facade.ErrNilProofProcessor, err)
+}
+
+func TestNewElrondProxyFacade_NilStatusProcessorShouldErr(t *testing.T) {
+	t.Parallel()
+
+	epf, err := facade.NewElrondProxyFacade(
+		&mock.ActionsProcessorStub{},
+		&mock.AccountProcessorStub{},
+		&mock.TransactionProcessorStub{},
+		&mock.SCQueryServiceStub{},
+		&mock.HeartbeatProcessorStub{},
+		&mock.ValidatorStatisticsProcessorStub{},
+		&mock.FaucetProcessorStub{},
+		&mock.NodeStatusProcessorStub{},
+		&mock.BlockProcessorStub{},
+		&mock.BlocksProcessorStub{},
+		&mock.ProofProcessorStub{},
+		publicKeyConverter,
+		&mock.ESDTSuppliesProcessorStub{},
+		nil,
+	)
+
+	assert.Nil(t, epf)
+	assert.Equal(t, facade.ErrNilStatusProcessor, err)
 }
 
 func TestNewElrondProxyFacade_ShouldWork(t *testing.T) {
@@ -267,6 +301,7 @@ func TestNewElrondProxyFacade_ShouldWork(t *testing.T) {
 		&mock.ProofProcessorStub{},
 		publicKeyConverter,
 		&mock.ESDTSuppliesProcessorStub{},
+		&mock.StatusProcessorStub{},
 	)
 
 	assert.NotNil(t, epf)
@@ -313,7 +348,9 @@ func TestNewElrondProxyFacade_GetBlocksByRound(t *testing.T) {
 		&mock.ProofProcessorStub{},
 		publicKeyConverter,
 		&mock.ESDTSuppliesProcessorStub{},
+		&mock.StatusProcessorStub{},
 	)
+	require.NoError(t, err)
 
 	ret, err := epf.GetBlocksByRound(3, true)
 	require.Equal(t, errGetBlockByRound, err)
@@ -347,6 +384,7 @@ func TestElrondProxyFacade_GetAccount(t *testing.T) {
 		&mock.ProofProcessorStub{},
 		publicKeyConverter,
 		&mock.ESDTSuppliesProcessorStub{},
+		&mock.StatusProcessorStub{},
 	)
 
 	_, _ = epf.GetAccount("")
@@ -378,6 +416,7 @@ func TestElrondProxyFacade_SendTransaction(t *testing.T) {
 		&mock.ProofProcessorStub{},
 		publicKeyConverter,
 		&mock.ESDTSuppliesProcessorStub{},
+		&mock.StatusProcessorStub{},
 	)
 
 	_, _, _ = epf.SendTransaction(&data.Transaction{})
@@ -408,6 +447,7 @@ func TestElrondProxyFacade_SimulateTransaction(t *testing.T) {
 		&mock.ProofProcessorStub{},
 		publicKeyConverter,
 		&mock.ESDTSuppliesProcessorStub{},
+		&mock.StatusProcessorStub{},
 	)
 
 	_, _ = epf.SimulateTransaction(&data.Transaction{}, false)
@@ -462,6 +502,7 @@ func TestElrondProxyFacade_SendUserFunds(t *testing.T) {
 		&mock.ProofProcessorStub{},
 		publicKeyConverter,
 		&mock.ESDTSuppliesProcessorStub{},
+		&mock.StatusProcessorStub{},
 	)
 
 	_ = epf.SendUserFunds("", big.NewInt(0))
@@ -492,6 +533,7 @@ func TestElrondProxyFacade_GetDataValue(t *testing.T) {
 		&mock.ProofProcessorStub{},
 		publicKeyConverter,
 		&mock.ESDTSuppliesProcessorStub{},
+		&mock.StatusProcessorStub{},
 	)
 
 	_, _ = epf.ExecuteSCQuery(nil)
@@ -528,6 +570,7 @@ func TestElrondProxyFacade_GetHeartbeatData(t *testing.T) {
 		&mock.ProofProcessorStub{},
 		publicKeyConverter,
 		&mock.ESDTSuppliesProcessorStub{},
+		&mock.StatusProcessorStub{},
 	)
 
 	actualResult, _ := epf.GetHeartbeatData()
@@ -561,6 +604,7 @@ func TestElrondProxyFacade_ReloadObservers(t *testing.T) {
 		&mock.ProofProcessorStub{},
 		publicKeyConverter,
 		&mock.ESDTSuppliesProcessorStub{},
+		&mock.StatusProcessorStub{},
 	)
 
 	actualResult := epf.ReloadObservers()
@@ -594,6 +638,7 @@ func TestElrondProxyFacade_ReloadFullHistoryObservers(t *testing.T) {
 		&mock.ProofProcessorStub{},
 		publicKeyConverter,
 		&mock.ESDTSuppliesProcessorStub{},
+		&mock.StatusProcessorStub{},
 	)
 
 	actualResult := epf.ReloadFullHistoryObservers()

--- a/facade/errors.go
+++ b/facade/errors.go
@@ -37,3 +37,6 @@ var ErrNilProofProcessor = errors.New("nil proof processor provided")
 
 // ErrNilESDTSuppliesProcessor signals that a nil esdt supplies processor has been provided
 var ErrNilESDTSuppliesProcessor = errors.New("nil esdt supplies processor")
+
+// ErrNilStatusProcessor signals that a nil status processor has been provided
+var ErrNilStatusProcessor = errors.New("nil status processor")

--- a/facade/interface.go
+++ b/facade/interface.go
@@ -111,5 +111,6 @@ type FaucetProcessor interface {
 
 // StatusProcessor defines what a component which will handle status request should do
 type StatusProcessor interface {
-	GetMetrics() (map[string]*data.EndpointMetrics, error)
+	GetMetrics() map[string]*data.EndpointMetrics
+	GetMetricsForPrometheus() string
 }

--- a/facade/interface.go
+++ b/facade/interface.go
@@ -108,3 +108,8 @@ type FaucetProcessor interface {
 		version uint32,
 	) (*data.Transaction, error)
 }
+
+// StatusProcessor defines what a component which will handle status request should do
+type StatusProcessor interface {
+	GetMetrics() (map[string]*data.EndpointMetrics, error)
+}

--- a/facade/mock/statusProcessorStub.go
+++ b/facade/mock/statusProcessorStub.go
@@ -6,14 +6,24 @@ import (
 
 // StatusProcessorStub -
 type StatusProcessorStub struct {
-	GetMetricsCalled func() (map[string]*data.EndpointMetrics, error)
+	GetMetricsCalled              func() map[string]*data.EndpointMetrics
+	GetMetricsForPrometheusCalled func() string
+}
+
+// GetMetricsForPrometheus -
+func (s *StatusProcessorStub) GetMetricsForPrometheus() string {
+	if s.GetMetricsForPrometheusCalled != nil {
+		return s.GetMetricsForPrometheusCalled()
+	}
+
+	return ""
 }
 
 // GetMetrics -
-func (s *StatusProcessorStub) GetMetrics() (map[string]*data.EndpointMetrics, error) {
+func (s *StatusProcessorStub) GetMetrics() map[string]*data.EndpointMetrics {
 	if s.GetMetricsCalled != nil {
 		return s.GetMetricsCalled()
 	}
 
-	return nil, nil
+	return nil
 }

--- a/facade/mock/statusProcessorStub.go
+++ b/facade/mock/statusProcessorStub.go
@@ -1,0 +1,19 @@
+package mock
+
+import (
+	"github.com/ElrondNetwork/elrond-proxy-go/data"
+)
+
+// StatusProcessorStub -
+type StatusProcessorStub struct {
+	GetMetricsCalled func() (map[string]*data.EndpointMetrics, error)
+}
+
+// GetMetrics -
+func (s *StatusProcessorStub) GetMetrics() (map[string]*data.EndpointMetrics, error) {
+	if s.GetMetricsCalled != nil {
+		return s.GetMetricsCalled()
+	}
+
+	return nil, nil
+}

--- a/metrics/errors.go
+++ b/metrics/errors.go
@@ -1,7 +1,0 @@
-package metrics
-
-import "errors"
-
-var errNegativeCacheSize = errors.New("negative cache size")
-
-var errNilMetricSaveFunction = errors.New("nil metrics save function")

--- a/metrics/errors.go
+++ b/metrics/errors.go
@@ -1,0 +1,7 @@
+package metrics
+
+import "errors"
+
+var errNegativeCacheSize = errors.New("negative cache size")
+
+var errNilMetricSaveFunction = errors.New("nil metrics save function")

--- a/metrics/statusMetrics.go
+++ b/metrics/statusMetrics.go
@@ -24,8 +24,8 @@ func NewStatusMetrics() *statusMetrics {
 
 // AddRequestData will add the received data to the metrics map
 func (sm *statusMetrics) AddRequestData(path string, withError bool, duration time.Duration) {
-	// TODO: analyze possible way of improving this function - launch on goroutines (with a max num of goroutines),
-	// or implement a queue mechanism for writing new data. Currently, the addition is done sequentially.
+	// TODO: refactor this by using a buffered channel that receives new request data and stores them into the map
+	// from time to time
 
 	sm.mutEndpointsOperations.Lock()
 	defer sm.mutEndpointsOperations.Unlock()
@@ -63,7 +63,12 @@ func (sm *statusMetrics) GetAll() map[string]*data.EndpointMetrics {
 	sm.mutEndpointsOperations.RLock()
 	defer sm.mutEndpointsOperations.RUnlock()
 
-	return sm.endpointMetrics
+	newMap := make(map[string]*data.EndpointMetrics)
+	for key, value := range sm.endpointMetrics {
+		newMap[key] = value
+	}
+
+	return newMap
 }
 
 // GetMetricsForPrometheus returns the metrics in a prometheus format

--- a/metrics/statusMetrics.go
+++ b/metrics/statusMetrics.go
@@ -1,0 +1,69 @@
+package metrics
+
+import (
+	"sync"
+	"time"
+
+	"github.com/ElrondNetwork/elrond-proxy-go/data"
+)
+
+// statusMetrics will handle displaying at /status/metrics all collected metrics
+type statusMetrics struct {
+	endpointMetrics        map[string]*data.EndpointMetrics
+	mutEndpointsOperations sync.RWMutex
+}
+
+// NewStatusMetrics will return an instance of the struct
+func NewStatusMetrics() *statusMetrics {
+	return &statusMetrics{
+		endpointMetrics: make(map[string]*data.EndpointMetrics),
+	}
+}
+
+// AddRequestData will add the received data to the metrics map
+func (sm *statusMetrics) AddRequestData(path string, withError bool, duration time.Duration) {
+	// TODO: analyze possible way of improving this function - launch on goroutines (with a max num of goroutines),
+	// or implement a queue mechanism for writing new data. Currently, the addition is done sequentially.
+
+	sm.mutEndpointsOperations.Lock()
+	defer sm.mutEndpointsOperations.Unlock()
+
+	currentData := sm.endpointMetrics[path]
+	withErrorIncrementalStep := uint64(0)
+	if withError {
+		withErrorIncrementalStep = 1
+	}
+	if currentData == nil {
+		sm.endpointMetrics[path] = &data.EndpointMetrics{
+			NumRequests:         1,
+			NumErrors:           withErrorIncrementalStep,
+			TotalResponseTime:   duration,
+			LowestResponseTime:  duration,
+			HighestResponseTime: duration,
+		}
+
+		return
+	}
+
+	currentData.NumRequests++
+	currentData.NumErrors += withErrorIncrementalStep
+	if duration < currentData.LowestResponseTime {
+		currentData.LowestResponseTime = duration
+	}
+	if duration > currentData.HighestResponseTime {
+		currentData.HighestResponseTime = duration
+	}
+	currentData.TotalResponseTime += duration
+}
+
+func (sm *statusMetrics) GetAll() map[string]*data.EndpointMetrics {
+	sm.mutEndpointsOperations.RLock()
+	defer sm.mutEndpointsOperations.RUnlock()
+
+	return sm.endpointMetrics
+}
+
+// IsInterfaceNil returns true if there is no value under the interface
+func (sm *statusMetrics) IsInterfaceNil() bool {
+	return sm == nil
+}

--- a/metrics/statusMetrics_test.go
+++ b/metrics/statusMetrics_test.go
@@ -1,0 +1,99 @@
+package metrics
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ElrondNetwork/elrond-go/core/check"
+	"github.com/ElrondNetwork/elrond-proxy-go/data"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewStatusMetrics(t *testing.T) {
+	t.Parallel()
+
+	sm := NewStatusMetrics()
+	require.False(t, check.IfNil(sm))
+}
+
+func TestStatusMetrics_AddRequestData(t *testing.T) {
+	t.Parallel()
+
+	t.Run("test when only a metric exists for an endpoint", testFirstMetric)
+	t.Run("test when multiple entries exist for an endpoint", testWhenMultipleMetrics)
+	t.Run("test when multiple entries for multiple endpoints", testWhenMultipleEntriesForMultipleEndpoints)
+}
+
+func testFirstMetric(t *testing.T) {
+	t.Parallel()
+
+	sm := NewStatusMetrics()
+
+	testEndpoint, testDuration := "/network/config", 1*time.Second
+	sm.AddRequestData(testEndpoint, false, testDuration)
+
+	res := sm.GetAll()
+	require.Equal(t, res[testEndpoint], &data.EndpointMetrics{
+		NumRequests:         1,
+		NumErrors:           0,
+		TotalResponseTime:   testDuration,
+		LowestResponseTime:  testDuration,
+		HighestResponseTime: testDuration,
+	})
+}
+
+func testWhenMultipleMetrics(t *testing.T) {
+	t.Parallel()
+
+	sm := NewStatusMetrics()
+
+	testEndpoint := "/network/config"
+	testDuration0, testDuration1, testDuration2 := 4*time.Millisecond, 20*time.Millisecond, 2*time.Millisecond
+	sm.AddRequestData(testEndpoint, false, testDuration0)
+	sm.AddRequestData(testEndpoint, true, testDuration1)
+	sm.AddRequestData(testEndpoint, false, testDuration2)
+
+	res := sm.GetAll()
+	require.Equal(t, res[testEndpoint], &data.EndpointMetrics{
+		NumRequests:         3,
+		NumErrors:           1,
+		TotalResponseTime:   testDuration0 + testDuration1 + testDuration2,
+		LowestResponseTime:  testDuration2,
+		HighestResponseTime: testDuration1,
+	})
+}
+
+func testWhenMultipleEntriesForMultipleEndpoints(t *testing.T) {
+	t.Parallel()
+
+	sm := NewStatusMetrics()
+
+	testEndpoint0, testEndpoint1 := "/network/config", "/network/esdts"
+
+	testDuration0End0, testDuration1End0 := time.Second, 5*time.Second
+	testDuration0End1, testDuration1End1 := time.Hour, 4*time.Hour
+
+	sm.AddRequestData(testEndpoint0, true, testDuration0End0)
+	sm.AddRequestData(testEndpoint0, false, testDuration1End0)
+
+	sm.AddRequestData(testEndpoint1, true, testDuration0End1)
+	sm.AddRequestData(testEndpoint1, true, testDuration1End1)
+
+	res := sm.GetAll()
+
+	require.Len(t, res, 2)
+	require.Equal(t, res[testEndpoint0], &data.EndpointMetrics{
+		NumRequests:         2,
+		NumErrors:           1,
+		TotalResponseTime:   testDuration0End0 + testDuration1End0,
+		LowestResponseTime:  testDuration0End0,
+		HighestResponseTime: testDuration1End0,
+	})
+	require.Equal(t, res[testEndpoint1], &data.EndpointMetrics{
+		NumRequests:         2,
+		NumErrors:           2,
+		TotalResponseTime:   testDuration0End1 + testDuration1End1,
+		LowestResponseTime:  testDuration0End1,
+		HighestResponseTime: testDuration1End1,
+	})
+}

--- a/metrics/statusMetrics_test.go
+++ b/metrics/statusMetrics_test.go
@@ -151,8 +151,7 @@ func TestStatusMetrics_ConcurrentOperations(t *testing.T) {
 				res := sm.GetAll()
 				delete(res, "endpoint_0")
 			case 2:
-				res := sm.GetAll()
-				delete(res, "endpoint_0")
+				_ = sm.GetMetricsForPrometheus()
 			}
 
 			wg.Done()

--- a/observer/nodesProviderFactory.go
+++ b/observer/nodesProviderFactory.go
@@ -51,7 +51,7 @@ func (npf *nodesProviderFactory) CreateFullHistoryNodes() (NodesProviderHandler,
 
 func getDisabledFullHistoryNodesProviderIfNeeded(err error) (NodesProviderHandler, error) {
 	if err == ErrEmptyObserversList {
-		log.Warn("no configuration found for full history nodes. Calls to endpoints specific to full history nodes" +
+		log.Warn("no configuration found for full history nodes. Calls to endpoints specific to full history nodes " +
 			"will return an error")
 		return NewDisabledNodesProvider("full history nodes not supported"), nil
 	}

--- a/process/errors.go
+++ b/process/errors.go
@@ -100,3 +100,6 @@ var ErrNilLogsMerger = errors.New("nil logs merger")
 
 // ErrNilSCQueryService signals that a nil smart contracts query service has been provided
 var ErrNilSCQueryService = errors.New("nil smart contracts query service provided")
+
+// ErrNilStatusMetricsProviders signals that a nil status metrics provider has been given
+var ErrNilStatusMetricsProvider = errors.New("nil status metrics provider")

--- a/process/interface.go
+++ b/process/interface.go
@@ -82,5 +82,6 @@ type SCQueryService interface {
 // StatusMetricsProvider defines what a status metrics provider should do
 type StatusMetricsProvider interface {
 	GetAll() map[string]*data.EndpointMetrics
+	GetMetricsForPrometheus() string
 	IsInterfaceNil() bool
 }

--- a/process/interface.go
+++ b/process/interface.go
@@ -78,3 +78,9 @@ type SCQueryService interface {
 	ExecuteQuery(query *data.SCQuery) (*vm.VMOutputApi, error)
 	IsInterfaceNil() bool
 }
+
+// StatusMetricsProvider defines what a status metrics provider should do
+type StatusMetricsProvider interface {
+	GetAll() map[string]*data.EndpointMetrics
+	IsInterfaceNil() bool
+}

--- a/process/mock/statusMetricsProviderStub.go
+++ b/process/mock/statusMetricsProviderStub.go
@@ -6,7 +6,17 @@ import (
 
 // StatusMetricsProviderStub -
 type StatusMetricsProviderStub struct {
-	GetAllCalled func() map[string]*data.EndpointMetrics
+	GetAllCalled                  func() map[string]*data.EndpointMetrics
+	GetMetricsForPrometheusCalled func() string
+}
+
+// GetMetricsForPrometheus -
+func (s *StatusMetricsProviderStub) GetMetricsForPrometheus() string {
+	if s.GetMetricsForPrometheusCalled != nil {
+		return s.GetMetricsForPrometheusCalled()
+	}
+
+	return ""
 }
 
 // GetAll -

--- a/process/mock/statusMetricsProviderStub.go
+++ b/process/mock/statusMetricsProviderStub.go
@@ -1,0 +1,24 @@
+package mock
+
+import (
+	"github.com/ElrondNetwork/elrond-proxy-go/data"
+)
+
+// StatusMetricsProviderStub -
+type StatusMetricsProviderStub struct {
+	GetAllCalled func() map[string]*data.EndpointMetrics
+}
+
+// GetAll -
+func (s *StatusMetricsProviderStub) GetAll() map[string]*data.EndpointMetrics {
+	if s.GetAllCalled != nil {
+		return s.GetAllCalled()
+	}
+
+	return make(map[string]*data.EndpointMetrics)
+}
+
+// IsInterfaceNil returns true if there is no value under the interface
+func (s *StatusMetricsProviderStub) IsInterfaceNil() bool {
+	return s == nil
+}

--- a/process/statusProcessor.go
+++ b/process/statusProcessor.go
@@ -27,8 +27,13 @@ func NewStatusProcessor(proc Processor, statusMetricsProvider StatusMetricsProvi
 }
 
 // GetMetrics returns the metrics for all the endpoints
-func (sp *StatusProcessor) GetMetrics() (map[string]*data.EndpointMetrics, error) {
+func (sp *StatusProcessor) GetMetrics() map[string]*data.EndpointMetrics {
 	metrics := sp.statusMetricsProvider.GetAll()
 
-	return metrics, nil
+	return metrics
+}
+
+// GetMetricsForPrometheus returns the metrics in a prometheus format
+func (sp *StatusProcessor) GetMetricsForPrometheus() string {
+	return sp.statusMetricsProvider.GetMetricsForPrometheus()
 }

--- a/process/statusProcessor.go
+++ b/process/statusProcessor.go
@@ -1,0 +1,34 @@
+package process
+
+import (
+	"github.com/ElrondNetwork/elrond-go/core/check"
+	"github.com/ElrondNetwork/elrond-proxy-go/data"
+)
+
+// StatusProcessor is able to process status requests
+type StatusProcessor struct {
+	proc                  Processor
+	statusMetricsProvider StatusMetricsProvider
+}
+
+// NewStatusProcessor creates a new instance of AccountProcessor
+func NewStatusProcessor(proc Processor, statusMetricsProvider StatusMetricsProvider) (*StatusProcessor, error) {
+	if check.IfNil(proc) {
+		return nil, ErrNilCoreProcessor
+	}
+	if check.IfNil(statusMetricsProvider) {
+		return nil, ErrNilStatusMetricsProvider
+	}
+
+	return &StatusProcessor{
+		proc:                  proc,
+		statusMetricsProvider: statusMetricsProvider,
+	}, nil
+}
+
+// GetMetrics returns the metrics for all the endpoints
+func (sp *StatusProcessor) GetMetrics() (map[string]*data.EndpointMetrics, error) {
+	metrics := sp.statusMetricsProvider.GetAll()
+
+	return metrics, nil
+}

--- a/process/statusProcessor.go
+++ b/process/statusProcessor.go
@@ -28,9 +28,7 @@ func NewStatusProcessor(proc Processor, statusMetricsProvider StatusMetricsProvi
 
 // GetMetrics returns the metrics for all the endpoints
 func (sp *StatusProcessor) GetMetrics() map[string]*data.EndpointMetrics {
-	metrics := sp.statusMetricsProvider.GetAll()
-
-	return metrics
+	return sp.statusMetricsProvider.GetAll()
 }
 
 // GetMetricsForPrometheus returns the metrics in a prometheus format

--- a/process/statusProcessor_test.go
+++ b/process/statusProcessor_test.go
@@ -52,7 +52,7 @@ func TestStatusProcessor_GetMetrics(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, sp)
 
-	metrics, err := sp.GetMetrics()
+	metrics := sp.GetMetrics()
 	require.NoError(t, err)
 	require.Equal(t, expectedMetrics, metrics)
 }

--- a/process/statusProcessor_test.go
+++ b/process/statusProcessor_test.go
@@ -1,0 +1,58 @@
+package process
+
+import (
+	"testing"
+
+	"github.com/ElrondNetwork/elrond-proxy-go/data"
+	"github.com/ElrondNetwork/elrond-proxy-go/process/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewStatusProcessor(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil base processor - should error", func(t *testing.T) {
+		t.Parallel()
+
+		sp, err := NewStatusProcessor(nil, &mock.StatusMetricsProviderStub{})
+		require.Nil(t, sp)
+		require.Equal(t, ErrNilCoreProcessor, err)
+	})
+
+	t.Run("nil status metric provider - should error", func(t *testing.T) {
+		t.Parallel()
+
+		sp, err := NewStatusProcessor(&mock.ProcessorStub{}, nil)
+		require.Nil(t, sp)
+		require.Equal(t, ErrNilStatusMetricsProvider, err)
+	})
+
+	t.Run("should work", func(t *testing.T) {
+		t.Parallel()
+
+		sp, err := NewStatusProcessor(&mock.ProcessorStub{}, &mock.StatusMetricsProviderStub{})
+		require.NoError(t, err)
+		require.NotNil(t, sp)
+	})
+}
+
+func TestStatusProcessor_GetMetrics(t *testing.T) {
+	t.Parallel()
+
+	expectedMetrics := map[string]*data.EndpointMetrics{
+		"endpoint0": {NumErrors: 5},
+		"endpoint1": {NumErrors: 37},
+	}
+	statusProvider := &mock.StatusMetricsProviderStub{
+		GetAllCalled: func() map[string]*data.EndpointMetrics {
+			return expectedMetrics
+		},
+	}
+	sp, err := NewStatusProcessor(&mock.ProcessorStub{}, statusProvider)
+	require.NoError(t, err)
+	require.NotNil(t, sp)
+
+	metrics, err := sp.GetMetrics()
+	require.NoError(t, err)
+	require.Equal(t, expectedMetrics, metrics)
+}

--- a/process/statusProcessor_test.go
+++ b/process/statusProcessor_test.go
@@ -56,3 +56,21 @@ func TestStatusProcessor_GetMetrics(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, expectedMetrics, metrics)
 }
+
+func TestStatusProcessor_GetMetricsForPrometheus(t *testing.T) {
+	t.Parallel()
+
+	expectedOutput := "metrics"
+	statusProvider := &mock.StatusMetricsProviderStub{
+		GetMetricsForPrometheusCalled: func() string {
+			return expectedOutput
+		},
+	}
+	sp, err := NewStatusProcessor(&mock.ProcessorStub{}, statusProvider)
+	require.NoError(t, err)
+	require.NotNil(t, sp)
+
+	metrics := sp.GetMetricsForPrometheus()
+	require.NoError(t, err)
+	require.Equal(t, expectedOutput, metrics)
+}

--- a/versions/factory/versionedFacadeCreator.go
+++ b/versions/factory/versionedFacadeCreator.go
@@ -27,6 +27,7 @@ type FacadeArgs struct {
 	ProofProcessor               facade.ProofProcessor
 	PubKeyConverter              core.PubkeyConverter
 	ESDTSuppliesProcessor        facade.ESDTSupplyProcessor
+	StatusProcessor              facade.StatusProcessor
 }
 
 // CreateVersionsRegistry creates the version registry instances and populates it with the versions and their handlers
@@ -107,6 +108,7 @@ func createVersionV1_0Facade(facadeArgs FacadeArgs) (*facadeVersions.ElrondProxy
 		ProofProcessor:               facadeArgs.ProofProcessor,
 		PubKeyConverter:              facadeArgs.PubKeyConverter,
 		ESDTSuppliesProcessor:        facadeArgs.ESDTSuppliesProcessor,
+		StatusProcessor:              facadeArgs.StatusProcessor,
 	}
 
 	commonFacade, err := createVersionedFacade(v1_0HandlerArgs)
@@ -164,6 +166,7 @@ func createVersionV_nextFacade(facadeArgs FacadeArgs) (data.FacadeHandler, error
 		ValidatorStatisticsProcessor: facadeArgs.ValidatorStatisticsProcessor,
 		PubKeyConverter:              facadeArgs.PubKeyConverter,
 		ESDTSuppliesProcessor:        facadeArgs.ESDTSuppliesProcessor,
+		StatusProcessor:              facadeArgs.StatusProcessor,
 	}
 
 	commonFacade, err := createVersionedFacade(v_nextHandlerArgs)
@@ -201,5 +204,6 @@ func createVersionedFacade(args FacadeArgs) (data.FacadeHandler, error) {
 		args.ProofProcessor,
 		args.PubKeyConverter,
 		args.ESDTSuppliesProcessor,
+		args.StatusProcessor,
 	)
 }


### PR DESCRIPTION
Exported metrics related to endpoints statistics, such as lowest response time, highest response times, number of requests, and so on