### PR TITLE
Fallback observers

### DIFF
--- a/cmd/proxy/config/config.toml
+++ b/cmd/proxy/config/config.toml
@@ -64,6 +64,7 @@
 
 # List of Observers. If you want to define a metachain observer (needed for validator statistics route) use
 # shard id 4294967295
+# Fallback observers which are only used when regular ones are offline should have IsFallback = true
 [[Observers]]
    ShardId = 0
    Address = "http://127.0.0.1:8081"
@@ -71,6 +72,11 @@
 [[Observers]]
    ShardId = 1
    Address = "http://127.0.0.1:8082"
+
+[[Observers]]
+   ShardId = 1
+   Address = "http://127.0.0.1:8083"
+   IsFallback = true
 
 [[FullHistoryNodes]]
    ShardId = 0

--- a/data/observer.go
+++ b/data/observer.go
@@ -2,9 +2,10 @@ package data
 
 // NodeData holds an observer data
 type NodeData struct {
-	ShardId  uint32
-	Address  string
-	IsSynced bool
+	ShardId    uint32
+	Address    string
+	IsSynced   bool
+	IsFallback bool
 }
 
 // NodesReloadResponse is a DTO that holds details about nodes reloading

--- a/observer/baseNodeProvider.go
+++ b/observer/baseNodeProvider.go
@@ -99,18 +99,25 @@ func (bnp *baseNodeProvider) UpdateNodesBasedOnSyncState(nodesWithSyncStatus []*
 func (bnp *baseNodeProvider) printSyncedNodesInShardsUnprotected() {
 	for shardID, nodes := range bnp.nodesMap {
 		inSyncAddresses := make([]string, 0)
-		fallbackAddresses := make([]string, 0)
+		inSyncFallbackAddresses := make([]string, 0)
 		for _, node := range nodes {
 			if node.IsFallback {
-				fallbackAddresses = append(fallbackAddresses, node.Address)
-				continue
+				continue // added in the next for
 			}
 			inSyncAddresses = append(inSyncAddresses, node.Address)
 		}
+
+		for _, activeFallbackNode := range bnp.syncedFallbackNodes {
+			if activeFallbackNode.ShardId == shardID {
+				inSyncFallbackAddresses = append(inSyncFallbackAddresses, activeFallbackNode.Address)
+			}
+		}
+
+		totalNumOfActiveNodes := len(inSyncAddresses) + len(inSyncFallbackAddresses)
 		log.Info(fmt.Sprintf("shard %d active nodes", shardID),
-			"observers count", len(nodes),
+			"observers count", totalNumOfActiveNodes,
 			"addresses", strings.Join(inSyncAddresses, ", "),
-			"fallback addresses", strings.Join(fallbackAddresses, ", "))
+			"fallback addresses", strings.Join(inSyncFallbackAddresses, ", "))
 	}
 }
 

--- a/observer/baseNodeProvider.go
+++ b/observer/baseNodeProvider.go
@@ -346,9 +346,7 @@ func (bnp *baseNodeProvider) getSyncedNodesForShardUnprotected(shardId uint32) (
 
 	syncedNodes := make([]*data.NodeData, 0)
 	for _, node := range nodesForShard {
-		if !node.IsFallback {
-			syncedNodes = append(syncedNodes, node)
-		}
+		syncedNodes = append(syncedNodes, node)
 	}
 
 	return syncedNodes, nil

--- a/observer/baseNodeProvider.go
+++ b/observer/baseNodeProvider.go
@@ -169,10 +169,6 @@ func (bnp *baseNodeProvider) addSyncedNodesUnprotected(receivedSyncedNodes []*da
 	}
 
 	bnp.nodesMap = nodesSliceToShardedMap(bnp.syncedNodes)
-	syncedFallbackNodesMap := nodesSliceToShardedMap(bnp.syncedFallbackNodes)
-	for shardId := range syncedFallbackNodesMap {
-		bnp.nodesMap[shardId] = append(bnp.nodesMap[shardId], syncedFallbackNodesMap[shardId]...)
-	}
 }
 
 func (bnp *baseNodeProvider) removeFromOutOfSyncIfNeededUnprotected(node *data.NodeData) {

--- a/observer/baseNodeProvider_test.go
+++ b/observer/baseNodeProvider_test.go
@@ -82,28 +82,32 @@ func TestInitAllNodesSlice_BalancesNumObserversDistribution(t *testing.T) {
 			{Address: "shard 0 - id 1"},
 			{Address: "shard 0 - id 2"},
 			{Address: "shard 0 - id 3"},
+			{Address: "shard 0 - id 4", IsFallback: true},
 		},
 		1: {
 			{Address: "shard 1 - id 0"},
 			{Address: "shard 1 - id 1"},
 			{Address: "shard 1 - id 2"},
 			{Address: "shard 1 - id 3"},
+			{Address: "shard 1 - id 4", IsFallback: true},
 		},
 		2: {
 			{Address: "shard 2 - id 0"},
 			{Address: "shard 2 - id 1"},
 			{Address: "shard 2 - id 2"},
 			{Address: "shard 2 - id 3"},
+			{Address: "shard 2 - id 4", IsFallback: true},
 		},
 		core.MetachainShardId: {
 			{Address: "shard meta - id 0"},
 			{Address: "shard meta - id 1"},
 			{Address: "shard meta - id 2"},
 			{Address: "shard meta - id 3"},
+			{Address: "shard meta - id 4", IsFallback: true},
 		},
 	}
 
-	expectedOrder := []string{
+	expectedSyncedOrder := []string{
 		"shard 0 - id 0",
 		"shard 1 - id 0",
 		"shard 2 - id 0",
@@ -122,9 +126,20 @@ func TestInitAllNodesSlice_BalancesNumObserversDistribution(t *testing.T) {
 		"shard meta - id 3",
 	}
 
-	result := initAllNodesSlice(nodesMap)
-	for i, r := range result {
-		assert.Equal(t, expectedOrder[i], r.Address)
+	resultSynced, resultFallback := initAllNodesSlice(nodesMap)
+	for i, r := range resultSynced {
+		assert.Equal(t, expectedSyncedOrder[i], r.Address)
+	}
+
+	expectedFallbackOrder := []string{
+		"shard 0 - id 4",
+		"shard 1 - id 4",
+		"shard 2 - id 4",
+		"shard meta - id 4",
+	}
+
+	for i, r := range resultFallback {
+		assert.Equal(t, expectedFallbackOrder[i], r.Address)
 	}
 }
 
@@ -152,10 +167,11 @@ func TestInitAllNodesSlice_UnbalancedNumObserversDistribution(t *testing.T) {
 			{Address: "shard meta - id 2"},
 			{Address: "shard meta - id 3"},
 			{Address: "shard meta - id 4"},
+			{Address: "shard meta - id 5", IsFallback: true},
 		},
 	}
 
-	expectedOrder := []string{
+	expectedSyncedOrder := []string{
 		"shard 0 - id 0",
 		"shard 1 - id 0",
 		"shard 2 - id 0",
@@ -171,9 +187,16 @@ func TestInitAllNodesSlice_UnbalancedNumObserversDistribution(t *testing.T) {
 		"shard meta - id 4",
 	}
 
-	result := initAllNodesSlice(nodesMap)
-	for i, r := range result {
-		assert.Equal(t, expectedOrder[i], r.Address)
+	resultSynced, resultFallback := initAllNodesSlice(nodesMap)
+	for i, r := range resultSynced {
+		assert.Equal(t, expectedSyncedOrder[i], r.Address)
+	}
+
+	expectedFallbackOrder := []string{
+		"shard meta - id 5",
+	}
+	for i, r := range resultFallback {
+		assert.Equal(t, expectedFallbackOrder[i], r.Address)
 	}
 }
 
@@ -201,7 +224,7 @@ func TestInitAllNodesSlice_EmptyObserversSliceForAShardShouldStillWork(t *testin
 		"shard meta - id 1",
 	}
 
-	result := initAllNodesSlice(nodesMap)
+	result, _ := initAllNodesSlice(nodesMap)
 	for i, r := range result {
 		assert.Equal(t, expectedOrder[i], r.Address)
 	}
@@ -220,7 +243,7 @@ func TestInitAllNodesSlice_SingleShardShouldWork(t *testing.T) {
 		"shard 0 - id 0",
 	}
 
-	result := initAllNodesSlice(nodesMap)
+	result, _ := initAllNodesSlice(nodesMap)
 	for i, r := range result {
 		assert.Equal(t, expectedOrder[i], r.Address)
 	}
@@ -229,30 +252,37 @@ func TestInitAllNodesSlice_SingleShardShouldWork(t *testing.T) {
 func TestBaseNodeProvider_UpdateNodesBasedOnSyncState(t *testing.T) {
 	t.Parallel()
 
-	allNodes := prepareNodes(6)
+	allNodes := prepareNodes(8)
+	setFallbackNodes(allNodes, 0, 1, 4, 5)
 
-	nodesMap := nodesSliceToShardedMap(allNodes)
 	bnp := &baseNodeProvider{
 		configurationFilePath: configurationPath,
-		nodesMap:              nodesMap,
-		syncedNodes:           allNodes,
 	}
+	_ = bnp.initNodesMaps(allNodes)
 
-	setSyncedStateToNodes(allNodes, false, 1, 2, 4, 5)
+	setSyncedStateToNodes(allNodes, false, 1, 2, 5, 6)
 
 	bnp.UpdateNodesBasedOnSyncState(allNodes)
 
 	require.Equal(t, []data.NodeData{
-		{Address: "addr0", ShardId: 0, IsSynced: true},
-		{Address: "addr3", ShardId: 1, IsSynced: true},
+		{Address: "addr3", ShardId: 0, IsSynced: true},
+		{Address: "addr7", ShardId: 1, IsSynced: true},
 	}, convertSlice(bnp.syncedNodes))
 
 	require.Equal(t, []data.NodeData{
-		{Address: "addr1", ShardId: 0, IsSynced: false},
+		{Address: "addr0", ShardId: 0, IsSynced: true, IsFallback: true},
+		{Address: "addr4", ShardId: 1, IsSynced: true, IsFallback: true},
+	}, convertSlice(bnp.syncedFallbackNodes))
+
+	require.Equal(t, []data.NodeData{
 		{Address: "addr2", ShardId: 0, IsSynced: false},
-		{Address: "addr4", ShardId: 1, IsSynced: false},
-		{Address: "addr5", ShardId: 1, IsSynced: false},
+		{Address: "addr6", ShardId: 1, IsSynced: false},
 	}, convertSlice(bnp.outOfSyncNodes))
+
+	require.Equal(t, []data.NodeData{
+		{Address: "addr1", ShardId: 0, IsSynced: false, IsFallback: true},
+		{Address: "addr5", ShardId: 1, IsSynced: false, IsFallback: true},
+	}, convertSlice(bnp.outOfSyncFallbackNodes))
 }
 
 func TestBaseNodeProvider_UpdateNodesBasedOnSyncStateShouldNotRemoveNodeIfNotEnoughLeft(t *testing.T) {
@@ -281,52 +311,90 @@ func TestBaseNodeProvider_UpdateNodesBasedOnSyncStateShouldNotRemoveNodeIfNotEno
 	}, convertSlice(bnp.outOfSyncNodes))
 }
 
+func TestBaseNodeProvider_UpdateNodesBasedOnSyncStateShouldMoveFallbackNode(t *testing.T) {
+	t.Parallel()
+
+	allNodes := prepareNodes(4)
+	setFallbackNodes(allNodes, 0)
+
+	bnp := &baseNodeProvider{
+		configurationFilePath: configurationPath,
+	}
+	_ = bnp.initNodesMaps(allNodes)
+
+	setSyncedStateToNodes(allNodes, false, 1)
+
+	bnp.UpdateNodesBasedOnSyncState(allNodes)
+
+	require.Equal(t, []data.NodeData{
+		{Address: "addr2", ShardId: 1, IsSynced: true},
+		{Address: "addr3", ShardId: 1, IsSynced: true},
+		{Address: "addr0", ShardId: 0, IsSynced: true, IsFallback: true},
+	}, convertSlice(bnp.syncedNodes))
+
+	require.Equal(t, []data.NodeData{
+		{Address: "addr0", ShardId: 0, IsSynced: true, IsFallback: true},
+	}, convertSlice(bnp.syncedFallbackNodes))
+
+	require.Equal(t, []data.NodeData{
+		{Address: "addr1", ShardId: 0, IsSynced: false},
+	}, convertSlice(bnp.outOfSyncNodes))
+
+	require.Equal(t, []data.NodeData{}, convertSlice(bnp.outOfSyncFallbackNodes))
+}
+
 func TestBaseNodeProvider_UpdateNodesBasedOnSyncStateShouldWorkAfterMultipleIterations(t *testing.T) {
 	t.Parallel()
 
 	allNodes := prepareNodes(10)
+	setFallbackNodes(allNodes, 0, 1, 5, 6)
 
-	nodesMap := nodesSliceToShardedMap(allNodes)
 	bnp := &baseNodeProvider{
 		configurationFilePath: configurationPath,
-		nodesMap:              nodesMap,
-		syncedNodes:           allNodes,
 	}
+	_ = bnp.initNodesMaps(allNodes)
 
 	setSyncedStateToNodes(allNodes, false, 1, 3, 5, 7, 9)
 
 	bnp.UpdateNodesBasedOnSyncState(allNodes)
 	require.Equal(t, []data.NodeData{
-		{Address: "addr0", ShardId: 0, IsSynced: true},
 		{Address: "addr2", ShardId: 0, IsSynced: true},
-		{Address: "addr4", ShardId: 0, IsSynced: true},
-		{Address: "addr6", ShardId: 1, IsSynced: true},
 		{Address: "addr8", ShardId: 1, IsSynced: true},
+		{Address: "addr4", ShardId: 0, IsSynced: true},
 	}, convertSlice(bnp.syncedNodes))
 	require.Equal(t, []data.NodeData{
-		{Address: "addr1", ShardId: 0, IsSynced: false},
+		{Address: "addr0", ShardId: 0, IsSynced: true, IsFallback: true},
+		{Address: "addr6", ShardId: 1, IsSynced: true, IsFallback: true},
+	}, convertSlice(bnp.syncedFallbackNodes))
+	require.Equal(t, []data.NodeData{
 		{Address: "addr3", ShardId: 0, IsSynced: false},
-		{Address: "addr5", ShardId: 1, IsSynced: false},
 		{Address: "addr7", ShardId: 1, IsSynced: false},
 		{Address: "addr9", ShardId: 1, IsSynced: false},
 	}, convertSlice(bnp.outOfSyncNodes))
+	require.Equal(t, []data.NodeData{
+		{Address: "addr1", ShardId: 0, IsSynced: false, IsFallback: true},
+		{Address: "addr5", ShardId: 1, IsSynced: false, IsFallback: true},
+	}, convertSlice(bnp.outOfSyncFallbackNodes))
 
 	allNodes = prepareNodes(10)
+	setFallbackNodes(allNodes, 0, 1, 5, 6)
 
 	bnp.UpdateNodesBasedOnSyncState(allNodes)
 
 	require.Equal(t, []data.NodeData{
-		{Address: "addr0", ShardId: 0, IsSynced: true},
 		{Address: "addr2", ShardId: 0, IsSynced: true},
-		{Address: "addr4", ShardId: 0, IsSynced: true},
-		{Address: "addr6", ShardId: 1, IsSynced: true},
 		{Address: "addr8", ShardId: 1, IsSynced: true},
-		{Address: "addr1", ShardId: 0, IsSynced: true},
+		{Address: "addr4", ShardId: 0, IsSynced: true},
 		{Address: "addr3", ShardId: 0, IsSynced: true},
-		{Address: "addr5", ShardId: 1, IsSynced: true},
 		{Address: "addr7", ShardId: 1, IsSynced: true},
 		{Address: "addr9", ShardId: 1, IsSynced: true},
 	}, convertSlice(bnp.syncedNodes))
+	require.Equal(t, []data.NodeData{
+		{Address: "addr0", ShardId: 0, IsSynced: true, IsFallback: true},
+		{Address: "addr6", ShardId: 1, IsSynced: true, IsFallback: true},
+		{Address: "addr1", ShardId: 0, IsSynced: true, IsFallback: true},
+		{Address: "addr5", ShardId: 1, IsSynced: true, IsFallback: true},
+	}, convertSlice(bnp.syncedFallbackNodes))
 }
 
 func prepareNodes(count int) []*data.NodeData {
@@ -349,6 +417,12 @@ func prepareNodes(count int) []*data.NodeData {
 func setSyncedStateToNodes(nodes []*data.NodeData, state bool, indices ...int) {
 	for _, idx := range indices {
 		nodes[idx].IsSynced = state
+	}
+}
+
+func setFallbackNodes(nodes []*data.NodeData, indices ...int) {
+	for _, idx := range indices {
+		nodes[idx].IsFallback = true
 	}
 }
 
@@ -381,9 +455,9 @@ func testComputeSyncedAndOutOfSyncNodesAllNodesSynced(t *testing.T) {
 	shardIDs := []uint32{0, 1}
 	input := []*data.NodeData{
 		{Address: "0", ShardId: 0, IsSynced: true},
-		{Address: "1", ShardId: 0, IsSynced: true},
+		{Address: "1", ShardId: 0, IsSynced: true, IsFallback: true},
 		{Address: "2", ShardId: 1, IsSynced: true},
-		{Address: "3", ShardId: 1, IsSynced: true},
+		{Address: "3", ShardId: 1, IsSynced: true, IsFallback: true},
 	}
 
 	synced, notSynced, _ := computeSyncedAndOutOfSyncNodes(input, shardIDs)
@@ -398,18 +472,22 @@ func testComputeSyncedAndOutOfSyncNodesEnoughSyncedObservers(t *testing.T) {
 	input := []*data.NodeData{
 		{Address: "0", ShardId: 0, IsSynced: true},
 		{Address: "1", ShardId: 0, IsSynced: false},
-		{Address: "2", ShardId: 1, IsSynced: true},
-		{Address: "3", ShardId: 1, IsSynced: false},
+		{Address: "2", ShardId: 0, IsSynced: true, IsFallback: true},
+		{Address: "3", ShardId: 1, IsSynced: true},
+		{Address: "4", ShardId: 1, IsSynced: false},
+		{Address: "5", ShardId: 1, IsSynced: true, IsFallback: true},
 	}
 
 	synced, notSynced, _ := computeSyncedAndOutOfSyncNodes(input, shardIDs)
 	require.Equal(t, []*data.NodeData{
 		{Address: "0", ShardId: 0, IsSynced: true},
-		{Address: "2", ShardId: 1, IsSynced: true},
+		{Address: "2", ShardId: 0, IsSynced: true, IsFallback: true},
+		{Address: "3", ShardId: 1, IsSynced: true},
+		{Address: "5", ShardId: 1, IsSynced: true, IsFallback: true},
 	}, synced)
 	require.Equal(t, []*data.NodeData{
 		{Address: "1", ShardId: 0, IsSynced: false},
-		{Address: "3", ShardId: 1, IsSynced: false},
+		{Address: "4", ShardId: 1, IsSynced: false},
 	}, notSynced)
 }
 
@@ -419,9 +497,9 @@ func testComputeSyncedAndOutOfSyncNodesAllNodesNotSynced(t *testing.T) {
 	shardIDs := []uint32{0, 1}
 	input := []*data.NodeData{
 		{Address: "0", ShardId: 0, IsSynced: false},
-		{Address: "1", ShardId: 0, IsSynced: false},
+		{Address: "1", ShardId: 0, IsSynced: false, IsFallback: true},
 		{Address: "2", ShardId: 1, IsSynced: false},
-		{Address: "3", ShardId: 1, IsSynced: false},
+		{Address: "3", ShardId: 1, IsSynced: false, IsFallback: true},
 	}
 
 	synced, notSynced, _ := computeSyncedAndOutOfSyncNodes(input, shardIDs)
@@ -430,8 +508,8 @@ func testComputeSyncedAndOutOfSyncNodesAllNodesNotSynced(t *testing.T) {
 		{Address: "2", ShardId: 1, IsSynced: false},
 	}, synced)
 	require.Equal(t, []*data.NodeData{
-		{Address: "1", ShardId: 0, IsSynced: false},
-		{Address: "3", ShardId: 1, IsSynced: false},
+		{Address: "1", ShardId: 0, IsSynced: false, IsFallback: true},
+		{Address: "3", ShardId: 1, IsSynced: false, IsFallback: true},
 	}, notSynced)
 }
 

--- a/observer/baseNodeProvider_test.go
+++ b/observer/baseNodeProvider_test.go
@@ -338,36 +338,7 @@ func TestBaseNodeProvider_UpdateNodesBasedOnSyncStateShouldWorkAfterMultipleIter
 	nodesCopy := copyNodes(allNodes)
 	setFallbackNodes(nodesCopy, 0, 1, 5, 6)
 	for i := 0; i < 3; i++ {
-		bnp.UpdateNodesBasedOnSyncState(nodesCopy)
-		require.Equal(t, []data.NodeData{
-			{Address: "addr2", ShardId: 0, IsSynced: true},
-			{Address: "addr3", ShardId: 0, IsSynced: true},
-			{Address: "addr4", ShardId: 0, IsSynced: true},
-			{Address: "addr7", ShardId: 1, IsSynced: true},
-			{Address: "addr8", ShardId: 1, IsSynced: true},
-			{Address: "addr9", ShardId: 1, IsSynced: true},
-		}, convertAndSortSlice(bnp.syncedNodes))
-		require.Equal(t, []data.NodeData{}, convertAndSortSlice(bnp.outOfSyncNodes))
-		require.Equal(t, []data.NodeData{
-			{Address: "addr0", ShardId: 0, IsSynced: true, IsFallback: true},
-			{Address: "addr1", ShardId: 0, IsSynced: true, IsFallback: true},
-			{Address: "addr5", ShardId: 1, IsSynced: true, IsFallback: true},
-			{Address: "addr6", ShardId: 1, IsSynced: true, IsFallback: true},
-		}, convertAndSortSlice(bnp.syncedFallbackNodes))
-		require.Equal(t, []data.NodeData{}, convertAndSortSlice(bnp.outOfSyncFallbackNodes))
-
-		require.Equal(t, []data.NodeData{
-			{Address: "addr0", ShardId: 0, IsSynced: true, IsFallback: true},
-			{Address: "addr1", ShardId: 0, IsSynced: true, IsFallback: true},
-			{Address: "addr2", ShardId: 0, IsSynced: true},
-			{Address: "addr3", ShardId: 0, IsSynced: true},
-			{Address: "addr4", ShardId: 0, IsSynced: true},
-			{Address: "addr5", ShardId: 1, IsSynced: true, IsFallback: true},
-			{Address: "addr6", ShardId: 1, IsSynced: true, IsFallback: true},
-			{Address: "addr7", ShardId: 1, IsSynced: true},
-			{Address: "addr8", ShardId: 1, IsSynced: true},
-			{Address: "addr9", ShardId: 1, IsSynced: true},
-		}, convertAndSortSlice(bnp.GetAllNodesWithSyncState()))
+		syncAllNodesAndCheck(t, nodesCopy, bnp)
 	}
 
 	// unsync some nodes, call Update 3 times same state
@@ -393,6 +364,7 @@ func TestBaseNodeProvider_UpdateNodesBasedOnSyncStateShouldWorkAfterMultipleIter
 			{Address: "addr1", ShardId: 0, IsSynced: false, IsFallback: true},
 			{Address: "addr5", ShardId: 1, IsSynced: false, IsFallback: true},
 		}, convertAndSortSlice(bnp.outOfSyncFallbackNodes))
+		require.Equal(t, 0, len(bnp.lastSyncedNodes))
 
 		require.Equal(t, []data.NodeData{
 			{Address: "addr0", ShardId: 0, IsSynced: true, IsFallback: true},
@@ -412,36 +384,7 @@ func TestBaseNodeProvider_UpdateNodesBasedOnSyncStateShouldWorkAfterMultipleIter
 	nodesCopy = prepareNodes(10)
 	setFallbackNodes(nodesCopy, 0, 1, 5, 6)
 	for i := 0; i < 3; i++ {
-		bnp.UpdateNodesBasedOnSyncState(nodesCopy)
-		require.Equal(t, []data.NodeData{
-			{Address: "addr2", ShardId: 0, IsSynced: true},
-			{Address: "addr3", ShardId: 0, IsSynced: true},
-			{Address: "addr4", ShardId: 0, IsSynced: true},
-			{Address: "addr7", ShardId: 1, IsSynced: true},
-			{Address: "addr8", ShardId: 1, IsSynced: true},
-			{Address: "addr9", ShardId: 1, IsSynced: true},
-		}, convertAndSortSlice(bnp.syncedNodes))
-		require.Equal(t, []data.NodeData{}, convertAndSortSlice(bnp.outOfSyncNodes))
-		require.Equal(t, []data.NodeData{
-			{Address: "addr0", ShardId: 0, IsSynced: true, IsFallback: true},
-			{Address: "addr1", ShardId: 0, IsSynced: true, IsFallback: true},
-			{Address: "addr5", ShardId: 1, IsSynced: true, IsFallback: true},
-			{Address: "addr6", ShardId: 1, IsSynced: true, IsFallback: true},
-		}, convertAndSortSlice(bnp.syncedFallbackNodes))
-		require.Equal(t, []data.NodeData{}, convertAndSortSlice(bnp.outOfSyncFallbackNodes))
-
-		require.Equal(t, []data.NodeData{
-			{Address: "addr0", ShardId: 0, IsSynced: true, IsFallback: true},
-			{Address: "addr1", ShardId: 0, IsSynced: true, IsFallback: true},
-			{Address: "addr2", ShardId: 0, IsSynced: true},
-			{Address: "addr3", ShardId: 0, IsSynced: true},
-			{Address: "addr4", ShardId: 0, IsSynced: true},
-			{Address: "addr5", ShardId: 1, IsSynced: true, IsFallback: true},
-			{Address: "addr6", ShardId: 1, IsSynced: true, IsFallback: true},
-			{Address: "addr7", ShardId: 1, IsSynced: true},
-			{Address: "addr8", ShardId: 1, IsSynced: true},
-			{Address: "addr9", ShardId: 1, IsSynced: true},
-		}, convertAndSortSlice(bnp.GetAllNodesWithSyncState()))
+		syncAllNodesAndCheck(t, nodesCopy, bnp)
 	}
 
 	// unsync all regular observers, call update 3 times same state
@@ -465,6 +408,8 @@ func TestBaseNodeProvider_UpdateNodesBasedOnSyncStateShouldWorkAfterMultipleIter
 			{Address: "addr8", ShardId: 1, IsSynced: false},
 			{Address: "addr9", ShardId: 1, IsSynced: false},
 		}, convertAndSortSlice(bnp.outOfSyncNodes))
+		require.Equal(t, data.NodeData{Address: "addr4", ShardId: 0, IsSynced: false}, *bnp.lastSyncedNodes[0])
+		require.Equal(t, data.NodeData{Address: "addr9", ShardId: 1, IsSynced: false}, *bnp.lastSyncedNodes[1])
 
 		require.Equal(t, []data.NodeData{
 			{Address: "addr0", ShardId: 0, IsSynced: true, IsFallback: true},
@@ -540,6 +485,7 @@ func TestBaseNodeProvider_UpdateNodesBasedOnSyncStateShouldWorkAfterMultipleIter
 			{Address: "addr5", ShardId: 1, IsSynced: false, IsFallback: true},
 			{Address: "addr6", ShardId: 1, IsSynced: false, IsFallback: true},
 		}, convertAndSortSlice(bnp.outOfSyncFallbackNodes))
+		require.Equal(t, 0, len(bnp.lastSyncedNodes))
 
 		require.Equal(t, []data.NodeData{
 			{Address: "addr0", ShardId: 0, IsSynced: false, IsFallback: true},
@@ -558,36 +504,7 @@ func TestBaseNodeProvider_UpdateNodesBasedOnSyncStateShouldWorkAfterMultipleIter
 	// sync all nodes
 	nodesCopy = prepareNodes(10)
 	setFallbackNodes(nodesCopy, 0, 1, 5, 6)
-	bnp.UpdateNodesBasedOnSyncState(nodesCopy)
-	require.Equal(t, []data.NodeData{
-		{Address: "addr2", ShardId: 0, IsSynced: true},
-		{Address: "addr3", ShardId: 0, IsSynced: true},
-		{Address: "addr4", ShardId: 0, IsSynced: true},
-		{Address: "addr7", ShardId: 1, IsSynced: true},
-		{Address: "addr8", ShardId: 1, IsSynced: true},
-		{Address: "addr9", ShardId: 1, IsSynced: true},
-	}, convertAndSortSlice(bnp.syncedNodes))
-	require.Equal(t, []data.NodeData{}, convertAndSortSlice(bnp.outOfSyncNodes))
-	require.Equal(t, []data.NodeData{
-		{Address: "addr0", ShardId: 0, IsSynced: true, IsFallback: true},
-		{Address: "addr1", ShardId: 0, IsSynced: true, IsFallback: true},
-		{Address: "addr5", ShardId: 1, IsSynced: true, IsFallback: true},
-		{Address: "addr6", ShardId: 1, IsSynced: true, IsFallback: true},
-	}, convertAndSortSlice(bnp.syncedFallbackNodes))
-	require.Equal(t, []data.NodeData{}, convertAndSortSlice(bnp.outOfSyncFallbackNodes))
-
-	require.Equal(t, []data.NodeData{
-		{Address: "addr0", ShardId: 0, IsSynced: true, IsFallback: true},
-		{Address: "addr1", ShardId: 0, IsSynced: true, IsFallback: true},
-		{Address: "addr2", ShardId: 0, IsSynced: true},
-		{Address: "addr3", ShardId: 0, IsSynced: true},
-		{Address: "addr4", ShardId: 0, IsSynced: true},
-		{Address: "addr5", ShardId: 1, IsSynced: true, IsFallback: true},
-		{Address: "addr6", ShardId: 1, IsSynced: true, IsFallback: true},
-		{Address: "addr7", ShardId: 1, IsSynced: true},
-		{Address: "addr8", ShardId: 1, IsSynced: true},
-		{Address: "addr9", ShardId: 1, IsSynced: true},
-	}, convertAndSortSlice(bnp.GetAllNodesWithSyncState()))
+	syncAllNodesAndCheck(t, nodesCopy, bnp)
 
 	// unsync fallbacks from shard 0
 	nodesCopy = copyNodes(nodesCopy)
@@ -610,6 +527,7 @@ func TestBaseNodeProvider_UpdateNodesBasedOnSyncStateShouldWorkAfterMultipleIter
 		{Address: "addr0", ShardId: 0, IsSynced: false, IsFallback: true},
 		{Address: "addr1", ShardId: 0, IsSynced: false, IsFallback: true},
 	}, convertAndSortSlice(bnp.outOfSyncFallbackNodes))
+	require.Equal(t, 0, len(bnp.lastSyncedNodes))
 
 	require.Equal(t, []data.NodeData{
 		{Address: "addr0", ShardId: 0, IsSynced: false, IsFallback: true},
@@ -646,6 +564,7 @@ func TestBaseNodeProvider_UpdateNodesBasedOnSyncStateShouldWorkAfterMultipleIter
 		{Address: "addr1", ShardId: 0, IsSynced: false, IsFallback: true},
 	}, convertAndSortSlice(bnp.outOfSyncFallbackNodes))
 	require.Equal(t, data.NodeData{Address: "addr4", ShardId: 0, IsSynced: false}, *bnp.lastSyncedNodes[0])
+	require.Equal(t, data.NodeData{Address: "addr9", ShardId: 1, IsSynced: false}, *bnp.lastSyncedNodes[1])
 
 	require.Equal(t, []data.NodeData{
 		{Address: "addr0", ShardId: 0, IsSynced: false, IsFallback: true},
@@ -658,6 +577,202 @@ func TestBaseNodeProvider_UpdateNodesBasedOnSyncStateShouldWorkAfterMultipleIter
 		{Address: "addr7", ShardId: 1, IsSynced: false},
 		{Address: "addr8", ShardId: 1, IsSynced: false},
 		{Address: "addr9", ShardId: 1, IsSynced: false},
+	}, convertAndSortSlice(bnp.GetAllNodesWithSyncState()))
+
+	// sync all nodes
+	nodesCopy = prepareNodes(10)
+	setFallbackNodes(nodesCopy, 0, 1, 5, 6)
+	syncAllNodesAndCheck(t, nodesCopy, bnp)
+
+	// unsync all observers from shard 0
+	nodesCopy = copyNodes(nodesCopy)
+	setSyncedStateToNodes(nodesCopy, false, 0, 1, 2, 3, 4)
+	bnp.UpdateNodesBasedOnSyncState(nodesCopy)
+	require.Equal(t, []data.NodeData{
+		{Address: "addr7", ShardId: 1, IsSynced: true},
+		{Address: "addr8", ShardId: 1, IsSynced: true},
+		{Address: "addr9", ShardId: 1, IsSynced: true},
+	}, convertAndSortSlice(bnp.syncedNodes))
+	require.Equal(t, []data.NodeData{
+		{Address: "addr5", ShardId: 1, IsSynced: true, IsFallback: true},
+		{Address: "addr6", ShardId: 1, IsSynced: true, IsFallback: true},
+	}, convertAndSortSlice(bnp.syncedFallbackNodes))
+	require.Equal(t, []data.NodeData{
+		{Address: "addr2", ShardId: 0, IsSynced: false},
+		{Address: "addr3", ShardId: 0, IsSynced: false},
+		{Address: "addr4", ShardId: 0, IsSynced: false},
+	}, convertAndSortSlice(bnp.outOfSyncNodes))
+	require.Equal(t, []data.NodeData{
+		{Address: "addr0", ShardId: 0, IsSynced: false, IsFallback: true},
+		{Address: "addr1", ShardId: 0, IsSynced: false, IsFallback: true},
+	}, convertAndSortSlice(bnp.outOfSyncFallbackNodes))
+	require.Equal(t, data.NodeData{Address: "addr4", ShardId: 0, IsSynced: false}, *bnp.lastSyncedNodes[0])
+	require.Equal(t, 1, len(bnp.lastSyncedNodes))
+
+	require.Equal(t, []data.NodeData{
+		{Address: "addr0", ShardId: 0, IsSynced: false, IsFallback: true},
+		{Address: "addr1", ShardId: 0, IsSynced: false, IsFallback: true},
+		{Address: "addr2", ShardId: 0, IsSynced: false},
+		{Address: "addr3", ShardId: 0, IsSynced: false},
+		{Address: "addr4", ShardId: 0, IsSynced: false},
+		{Address: "addr5", ShardId: 1, IsSynced: true, IsFallback: true},
+		{Address: "addr6", ShardId: 1, IsSynced: true, IsFallback: true},
+		{Address: "addr7", ShardId: 1, IsSynced: true},
+		{Address: "addr8", ShardId: 1, IsSynced: true},
+		{Address: "addr9", ShardId: 1, IsSynced: true},
+	}, convertAndSortSlice(bnp.GetAllNodesWithSyncState()))
+
+	// sync all nodes
+	nodesCopy = prepareNodes(10)
+	setFallbackNodes(nodesCopy, 0, 1, 5, 6)
+	syncAllNodesAndCheck(t, nodesCopy, bnp)
+
+	// unsync last regular observer from shard 0, call update 3 times
+	nodesCopy = copyNodes(nodesCopy)
+	setSyncedStateToNodes(nodesCopy, false, 4)
+	for i := 0; i < 3; i++ {
+		bnp.UpdateNodesBasedOnSyncState(nodesCopy)
+		require.Equal(t, []data.NodeData{
+			{Address: "addr2", ShardId: 0, IsSynced: true},
+			{Address: "addr3", ShardId: 0, IsSynced: true},
+			{Address: "addr7", ShardId: 1, IsSynced: true},
+			{Address: "addr8", ShardId: 1, IsSynced: true},
+			{Address: "addr9", ShardId: 1, IsSynced: true},
+		}, convertAndSortSlice(bnp.syncedNodes))
+		require.Equal(t, []data.NodeData{
+			{Address: "addr0", ShardId: 0, IsSynced: true, IsFallback: true},
+			{Address: "addr1", ShardId: 0, IsSynced: true, IsFallback: true},
+			{Address: "addr5", ShardId: 1, IsSynced: true, IsFallback: true},
+			{Address: "addr6", ShardId: 1, IsSynced: true, IsFallback: true},
+		}, convertAndSortSlice(bnp.syncedFallbackNodes))
+		require.Equal(t, []data.NodeData{
+			{Address: "addr4", ShardId: 0, IsSynced: false},
+		}, convertAndSortSlice(bnp.outOfSyncNodes))
+		require.Equal(t, []data.NodeData{}, convertAndSortSlice(bnp.outOfSyncFallbackNodes))
+		require.Equal(t, 0, len(bnp.lastSyncedNodes))
+
+		require.Equal(t, []data.NodeData{
+			{Address: "addr0", ShardId: 0, IsSynced: true, IsFallback: true},
+			{Address: "addr1", ShardId: 0, IsSynced: true, IsFallback: true},
+			{Address: "addr2", ShardId: 0, IsSynced: true},
+			{Address: "addr3", ShardId: 0, IsSynced: true},
+			{Address: "addr4", ShardId: 0, IsSynced: false},
+			{Address: "addr5", ShardId: 1, IsSynced: true, IsFallback: true},
+			{Address: "addr6", ShardId: 1, IsSynced: true, IsFallback: true},
+			{Address: "addr7", ShardId: 1, IsSynced: true},
+			{Address: "addr8", ShardId: 1, IsSynced: true},
+			{Address: "addr9", ShardId: 1, IsSynced: true},
+		}, convertAndSortSlice(bnp.GetAllNodesWithSyncState()))
+	}
+
+	// unsync all regular observers from shard 0, call update 3 times
+	nodesCopy = copyNodes(nodesCopy)
+	setSyncedStateToNodes(nodesCopy, false, 2, 3)
+	for i := 0; i < 3; i++ {
+		bnp.UpdateNodesBasedOnSyncState(nodesCopy)
+		require.Equal(t, []data.NodeData{
+			{Address: "addr7", ShardId: 1, IsSynced: true},
+			{Address: "addr8", ShardId: 1, IsSynced: true},
+			{Address: "addr9", ShardId: 1, IsSynced: true},
+		}, convertAndSortSlice(bnp.syncedNodes))
+		require.Equal(t, []data.NodeData{
+			{Address: "addr0", ShardId: 0, IsSynced: true, IsFallback: true},
+			{Address: "addr1", ShardId: 0, IsSynced: true, IsFallback: true},
+			{Address: "addr5", ShardId: 1, IsSynced: true, IsFallback: true},
+			{Address: "addr6", ShardId: 1, IsSynced: true, IsFallback: true},
+		}, convertAndSortSlice(bnp.syncedFallbackNodes))
+		require.Equal(t, []data.NodeData{
+			{Address: "addr2", ShardId: 0, IsSynced: false},
+			{Address: "addr3", ShardId: 0, IsSynced: false},
+			{Address: "addr4", ShardId: 0, IsSynced: false},
+		}, convertAndSortSlice(bnp.outOfSyncNodes))
+		require.Equal(t, []data.NodeData{}, convertAndSortSlice(bnp.outOfSyncFallbackNodes))
+		require.Equal(t, data.NodeData{Address: "addr3", ShardId: 0, IsSynced: false}, *bnp.lastSyncedNodes[0]) // last synced
+		require.Equal(t, 1, len(bnp.lastSyncedNodes))
+
+		require.Equal(t, []data.NodeData{
+			{Address: "addr0", ShardId: 0, IsSynced: true, IsFallback: true},
+			{Address: "addr1", ShardId: 0, IsSynced: true, IsFallback: true},
+			{Address: "addr2", ShardId: 0, IsSynced: false},
+			{Address: "addr3", ShardId: 0, IsSynced: false},
+			{Address: "addr4", ShardId: 0, IsSynced: false},
+			{Address: "addr5", ShardId: 1, IsSynced: true, IsFallback: true},
+			{Address: "addr6", ShardId: 1, IsSynced: true, IsFallback: true},
+			{Address: "addr7", ShardId: 1, IsSynced: true},
+			{Address: "addr8", ShardId: 1, IsSynced: true},
+			{Address: "addr9", ShardId: 1, IsSynced: true},
+		}, convertAndSortSlice(bnp.GetAllNodesWithSyncState()))
+	}
+
+	// unsync all fallback observers from shard 0
+	nodesCopy = copyNodes(nodesCopy)
+	setSyncedStateToNodes(nodesCopy, false, 0, 1)
+	bnp.UpdateNodesBasedOnSyncState(nodesCopy)
+	require.Equal(t, []data.NodeData{
+		{Address: "addr7", ShardId: 1, IsSynced: true},
+		{Address: "addr8", ShardId: 1, IsSynced: true},
+		{Address: "addr9", ShardId: 1, IsSynced: true},
+	}, convertAndSortSlice(bnp.syncedNodes))
+	require.Equal(t, []data.NodeData{
+		{Address: "addr5", ShardId: 1, IsSynced: true, IsFallback: true},
+		{Address: "addr6", ShardId: 1, IsSynced: true, IsFallback: true},
+	}, convertAndSortSlice(bnp.syncedFallbackNodes))
+	require.Equal(t, []data.NodeData{
+		{Address: "addr2", ShardId: 0, IsSynced: false},
+		{Address: "addr3", ShardId: 0, IsSynced: false},
+		{Address: "addr4", ShardId: 0, IsSynced: false},
+	}, convertAndSortSlice(bnp.outOfSyncNodes))
+	require.Equal(t, []data.NodeData{
+		{Address: "addr0", ShardId: 0, IsSynced: false, IsFallback: true},
+		{Address: "addr1", ShardId: 0, IsSynced: false, IsFallback: true},
+	}, convertAndSortSlice(bnp.outOfSyncFallbackNodes))
+	require.Equal(t, data.NodeData{Address: "addr3", ShardId: 0, IsSynced: false}, *bnp.lastSyncedNodes[0])
+	require.Equal(t, 1, len(bnp.lastSyncedNodes))
+
+	require.Equal(t, []data.NodeData{
+		{Address: "addr0", ShardId: 0, IsSynced: false, IsFallback: true},
+		{Address: "addr1", ShardId: 0, IsSynced: false, IsFallback: true},
+		{Address: "addr2", ShardId: 0, IsSynced: false},
+		{Address: "addr3", ShardId: 0, IsSynced: false},
+		{Address: "addr4", ShardId: 0, IsSynced: false},
+		{Address: "addr5", ShardId: 1, IsSynced: true, IsFallback: true},
+		{Address: "addr6", ShardId: 1, IsSynced: true, IsFallback: true},
+		{Address: "addr7", ShardId: 1, IsSynced: true},
+		{Address: "addr8", ShardId: 1, IsSynced: true},
+		{Address: "addr9", ShardId: 1, IsSynced: true},
+	}, convertAndSortSlice(bnp.GetAllNodesWithSyncState()))
+}
+
+func syncAllNodesAndCheck(t *testing.T, nodes []*data.NodeData, bnp *baseNodeProvider) {
+	bnp.UpdateNodesBasedOnSyncState(nodes)
+	require.Equal(t, []data.NodeData{
+		{Address: "addr2", ShardId: 0, IsSynced: true},
+		{Address: "addr3", ShardId: 0, IsSynced: true},
+		{Address: "addr4", ShardId: 0, IsSynced: true},
+		{Address: "addr7", ShardId: 1, IsSynced: true},
+		{Address: "addr8", ShardId: 1, IsSynced: true},
+		{Address: "addr9", ShardId: 1, IsSynced: true},
+	}, convertAndSortSlice(bnp.syncedNodes))
+	require.Equal(t, []data.NodeData{}, convertAndSortSlice(bnp.outOfSyncNodes))
+	require.Equal(t, []data.NodeData{
+		{Address: "addr0", ShardId: 0, IsSynced: true, IsFallback: true},
+		{Address: "addr1", ShardId: 0, IsSynced: true, IsFallback: true},
+		{Address: "addr5", ShardId: 1, IsSynced: true, IsFallback: true},
+		{Address: "addr6", ShardId: 1, IsSynced: true, IsFallback: true},
+	}, convertAndSortSlice(bnp.syncedFallbackNodes))
+	require.Equal(t, 0, len(bnp.lastSyncedNodes))
+
+	require.Equal(t, []data.NodeData{
+		{Address: "addr0", ShardId: 0, IsSynced: true, IsFallback: true},
+		{Address: "addr1", ShardId: 0, IsSynced: true, IsFallback: true},
+		{Address: "addr2", ShardId: 0, IsSynced: true},
+		{Address: "addr3", ShardId: 0, IsSynced: true},
+		{Address: "addr4", ShardId: 0, IsSynced: true},
+		{Address: "addr5", ShardId: 1, IsSynced: true, IsFallback: true},
+		{Address: "addr6", ShardId: 1, IsSynced: true, IsFallback: true},
+		{Address: "addr7", ShardId: 1, IsSynced: true},
+		{Address: "addr8", ShardId: 1, IsSynced: true},
+		{Address: "addr9", ShardId: 1, IsSynced: true},
 	}, convertAndSortSlice(bnp.GetAllNodesWithSyncState()))
 }
 

--- a/observer/baseNodeProvider_test.go
+++ b/observer/baseNodeProvider_test.go
@@ -468,6 +468,13 @@ func TestBaseNodeProvider_UpdateNodesBasedOnSyncStateShouldWorkAfterMultipleIter
 		{Address: "addr1", ShardId: 0, IsSynced: false, IsFallback: true},
 		{Address: "addr5", ShardId: 1, IsSynced: false, IsFallback: true},
 	}, convertSlice(bnp.outOfSyncFallbackNodes))
+	require.Equal(t, []data.NodeData{
+		{Address: "addr2", ShardId: 0, IsSynced: true},
+		{Address: "addr4", ShardId: 0, IsSynced: true},
+	}, convertSlice(bnp.nodesMap[0]))
+	require.Equal(t, []data.NodeData{
+		{Address: "addr8", ShardId: 1, IsSynced: true},
+	}, convertSlice(bnp.nodesMap[1]))
 
 	nodesCopy = prepareNodes(10)
 	setFallbackNodes(nodesCopy, 0, 1, 5, 6)
@@ -488,6 +495,16 @@ func TestBaseNodeProvider_UpdateNodesBasedOnSyncStateShouldWorkAfterMultipleIter
 		{Address: "addr1", ShardId: 0, IsSynced: true, IsFallback: true},
 		{Address: "addr5", ShardId: 1, IsSynced: true, IsFallback: true},
 	}, convertSlice(bnp.syncedFallbackNodes))
+	require.Equal(t, []data.NodeData{
+		{Address: "addr2", ShardId: 0, IsSynced: true},
+		{Address: "addr4", ShardId: 0, IsSynced: true},
+		{Address: "addr3", ShardId: 0, IsSynced: true},
+	}, convertSlice(bnp.nodesMap[0]))
+	require.Equal(t, []data.NodeData{
+		{Address: "addr8", ShardId: 1, IsSynced: true},
+		{Address: "addr7", ShardId: 1, IsSynced: true},
+		{Address: "addr9", ShardId: 1, IsSynced: true},
+	}, convertSlice(bnp.nodesMap[1]))
 
 	// unsync all nodes
 	setSyncedStateToNodes(nodesCopy, false, 2, 3, 4, 7, 8, 9)
@@ -513,6 +530,14 @@ func TestBaseNodeProvider_UpdateNodesBasedOnSyncStateShouldWorkAfterMultipleIter
 		{Address: "addr8", ShardId: 1, IsSynced: false},
 		{Address: "addr9", ShardId: 1, IsSynced: false},
 	}, convertSlice(bnp.outOfSyncNodes))
+	require.Equal(t, []data.NodeData{
+		{Address: "addr0", ShardId: 0, IsSynced: true, IsFallback: true},
+		{Address: "addr1", ShardId: 0, IsSynced: true, IsFallback: true},
+	}, convertSlice(bnp.nodesMap[0]))
+	require.Equal(t, []data.NodeData{
+		{Address: "addr5", ShardId: 1, IsSynced: true, IsFallback: true},
+		{Address: "addr6", ShardId: 1, IsSynced: true, IsFallback: true},
+	}, convertSlice(bnp.nodesMap[1]))
 
 	// bring one node on each shard back
 	setSyncedStateToNodes(nodesCopy, true, 2, 7)
@@ -534,6 +559,12 @@ func TestBaseNodeProvider_UpdateNodesBasedOnSyncStateShouldWorkAfterMultipleIter
 		{Address: "addr8", ShardId: 1, IsSynced: false},
 		{Address: "addr9", ShardId: 1, IsSynced: false},
 	}, convertSlice(bnp.outOfSyncNodes))
+	require.Equal(t, []data.NodeData{
+		{Address: "addr2", ShardId: 0, IsSynced: true},
+	}, convertSlice(bnp.nodesMap[0]))
+	require.Equal(t, []data.NodeData{
+		{Address: "addr7", ShardId: 1, IsSynced: true},
+	}, convertSlice(bnp.nodesMap[1]))
 }
 
 func prepareNodes(count int) []*data.NodeData {

--- a/observer/circularQueueNodesProvider.go
+++ b/observer/circularQueueNodesProvider.go
@@ -21,7 +21,7 @@ func NewCircularQueueNodesProvider(observers []*data.NodeData, configurationFile
 		configurationFilePath: configurationFilePath,
 	}
 
-	err := bop.initNodesMaps(observers)
+	err := bop.initNodes(observers)
 	if err != nil {
 		return nil, err
 	}
@@ -55,7 +55,10 @@ func (cqnp *circularQueueNodesProvider) GetAllNodes() ([]*data.NodeData, error) 
 	cqnp.mutNodes.Lock()
 	defer cqnp.mutNodes.Unlock()
 
-	allNodes := cqnp.syncedNodes
+	allNodes, err := cqnp.getSyncedNodesUnprotected()
+	if err != nil {
+		return nil, err
+	}
 
 	position := cqnp.computeCounterForAllNodes(uint32(len(allNodes)))
 	sliceToRet := append(allNodes[position:], allNodes[:position]...)

--- a/observer/circularQueueNodesProvider.go
+++ b/observer/circularQueueNodesProvider.go
@@ -39,13 +39,13 @@ func (cqnp *circularQueueNodesProvider) GetNodesByShardId(shardId uint32) ([]*da
 	cqnp.mutNodes.Lock()
 	defer cqnp.mutNodes.Unlock()
 
-	nodesForShard := cqnp.nodesMap[shardId]
-	if len(nodesForShard) == 0 {
-		return nil, ErrShardNotAvailable
+	syncedNodesForShard, err := cqnp.getSyncedNodesForShardUnprotected(shardId)
+	if err != nil {
+		return nil, err
 	}
 
-	position := cqnp.computeCounterForShard(shardId, uint32(len(nodesForShard)))
-	sliceToRet := append(nodesForShard[position:], nodesForShard[:position]...)
+	position := cqnp.computeCounterForShard(shardId, uint32(len(syncedNodesForShard)))
+	sliceToRet := append(syncedNodesForShard[position:], syncedNodesForShard[:position]...)
 
 	return sliceToRet, nil
 }

--- a/observer/simpleNodesProvider.go
+++ b/observer/simpleNodesProvider.go
@@ -16,7 +16,7 @@ func NewSimpleNodesProvider(observers []*data.NodeData, configurationFilePath st
 		configurationFilePath: configurationFilePath,
 	}
 
-	err := bop.initNodesMaps(observers)
+	err := bop.initNodes(observers)
 	if err != nil {
 		return nil, err
 	}
@@ -39,7 +39,7 @@ func (snp *simpleNodesProvider) GetAllNodes() ([]*data.NodeData, error) {
 	snp.mutNodes.RLock()
 	defer snp.mutNodes.RUnlock()
 
-	return snp.syncedNodes, nil
+	return snp.getSyncedNodesUnprotected()
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/observer/simpleNodesProvider.go
+++ b/observer/simpleNodesProvider.go
@@ -31,12 +31,7 @@ func (snp *simpleNodesProvider) GetNodesByShardId(shardId uint32) ([]*data.NodeD
 	snp.mutNodes.RLock()
 	defer snp.mutNodes.RUnlock()
 
-	nodesForShard, ok := snp.nodesMap[shardId]
-	if !ok {
-		return nil, ErrShardNotAvailable
-	}
-
-	return nodesForShard, nil
+	return snp.getSyncedNodesForShardUnprotected(shardId)
 }
 
 // GetAllNodes will return a slice containing all the nodes

--- a/process/baseProcessor.go
+++ b/process/baseProcessor.go
@@ -420,7 +420,8 @@ func (bp *BaseProcessor) isNodeSynced(node *proxyData.NodeData) (bool, error) {
 		"nonce", nonce,
 		"probable highest nonce", probableHighestNonce,
 		"is synced", isNodeSynced,
-		"is ready for VM Queries", isReadyForVMQueries)
+		"is ready for VM Queries", isReadyForVMQueries,
+		"is fallback", node.IsFallback)
 
 	if !isReadyForVMQueries {
 		isNodeSynced = false


### PR DESCRIPTION
Added fallback mechanism - when (and only when) regular observers aren't online or in sync, fallback observers will be used for requests, until regular observers are back online