### PR TITLE
Fix current shard condition on HbV2

### DIFF
--- a/process/heartbeatProcessor.go
+++ b/process/heartbeatProcessor.go
@@ -102,8 +102,9 @@ func (hbp *HeartbeatProcessor) getHeartbeatsFromApi() (*data.HeartbeatResponse, 
 func (hbp *HeartbeatProcessor) addMessagesToMap(responseMap map[string]data.PubKeyHeartbeat, heartbeats []data.PubKeyHeartbeat, observerShard uint32) {
 	for _, heartbeatMessage := range heartbeats {
 		isMessageFromCurrentShard := heartbeatMessage.ComputedShardID == observerShard
-		isNodeAfterShuffleOut := heartbeatMessage.ReceivedShardID == observerShard
-		if !isMessageFromCurrentShard && !isNodeAfterShuffleOut {
+		isMessageFromShardAfterShuffleOut := heartbeatMessage.ReceivedShardID == observerShard
+		belongToCurrentShard := isMessageFromCurrentShard || isMessageFromShardAfterShuffleOut
+		if !belongToCurrentShard {
 			continue
 		}
 

--- a/process/heartbeatProcessor.go
+++ b/process/heartbeatProcessor.go
@@ -106,8 +106,13 @@ func (hbp *HeartbeatProcessor) addMessagesToMap(responseMap map[string]data.PubK
 			continue
 		}
 
-		_, found := responseMap[heartbeatMessage.PublicKey]
+		oldMessage, found := responseMap[heartbeatMessage.PublicKey]
 		if !found {
+			responseMap[heartbeatMessage.PublicKey] = heartbeatMessage
+			continue // needed because the above get will return a default struct which with IsActive=false
+		}
+
+		if !oldMessage.IsActive && heartbeatMessage.IsActive {
 			responseMap[heartbeatMessage.PublicKey] = heartbeatMessage
 		}
 	}

--- a/process/heartbeatProcessor.go
+++ b/process/heartbeatProcessor.go
@@ -111,7 +111,7 @@ func (hbp *HeartbeatProcessor) addMessagesToMap(responseMap map[string]data.PubK
 		oldMessage, found := responseMap[heartbeatMessage.PublicKey]
 		if !found {
 			responseMap[heartbeatMessage.PublicKey] = heartbeatMessage
-			continue // needed because the above get will return a default struct which with IsActive=false
+			continue // needed because the above get will return a default struct which has IsActive set to false
 		}
 
 		if !oldMessage.IsActive && heartbeatMessage.IsActive {

--- a/process/heartbeatProcessor.go
+++ b/process/heartbeatProcessor.go
@@ -102,7 +102,8 @@ func (hbp *HeartbeatProcessor) getHeartbeatsFromApi() (*data.HeartbeatResponse, 
 func (hbp *HeartbeatProcessor) addMessagesToMap(responseMap map[string]data.PubKeyHeartbeat, heartbeats []data.PubKeyHeartbeat, observerShard uint32) {
 	for _, heartbeatMessage := range heartbeats {
 		isMessageFromCurrentShard := heartbeatMessage.ComputedShardID == observerShard
-		if !isMessageFromCurrentShard {
+		isNodeAfterShuffleOut := heartbeatMessage.ReceivedShardID == observerShard
+		if !isMessageFromCurrentShard && !isNodeAfterShuffleOut {
 			continue
 		}
 

--- a/process/heartbeatProcessor.go
+++ b/process/heartbeatProcessor.go
@@ -101,7 +101,7 @@ func (hbp *HeartbeatProcessor) getHeartbeatsFromApi() (*data.HeartbeatResponse, 
 
 func (hbp *HeartbeatProcessor) addMessagesToMap(responseMap map[string]data.PubKeyHeartbeat, heartbeats []data.PubKeyHeartbeat, observerShard uint32) {
 	for _, heartbeatMessage := range heartbeats {
-		isMessageFromCurrentShard := heartbeatMessage.ReceivedShardID == observerShard
+		isMessageFromCurrentShard := heartbeatMessage.ComputedShardID == observerShard
 		if !isMessageFromCurrentShard {
 			continue
 		}

--- a/process/heartbeatProcessor_test.go
+++ b/process/heartbeatProcessor_test.go
@@ -244,11 +244,19 @@ func TestHeartbeatProcessor_GetHeartbeatDataShouldReturnDataFromApiBecauseCacheD
 				PublicKey:       "pk1",
 				IsActive:        false,
 				ComputedShardID: 0,
+				ReceivedShardID: 0,
 			},
 			{
 				PublicKey:       "pk2",
 				IsActive:        true,
 				ComputedShardID: 0,
+				ReceivedShardID: 0,
+			},
+			{
+				PublicKey:       "pk4", // node after shuffle out, moved from shard 0 to 1
+				IsActive:        false,
+				ComputedShardID: 0,
+				ReceivedShardID: 0,
 			},
 		},
 	}
@@ -258,11 +266,19 @@ func TestHeartbeatProcessor_GetHeartbeatDataShouldReturnDataFromApiBecauseCacheD
 				PublicKey:       "pk1", // same as on first call
 				IsActive:        true,
 				ComputedShardID: 1,
+				ReceivedShardID: 1,
 			},
 			{
 				PublicKey:       "pk3",
 				IsActive:        true,
 				ComputedShardID: 1,
+				ReceivedShardID: 1,
+			},
+			{
+				PublicKey:       "pk4",
+				IsActive:        true,
+				ComputedShardID: 1,
+				ReceivedShardID: 0,
 			},
 		},
 	}
@@ -272,16 +288,25 @@ func TestHeartbeatProcessor_GetHeartbeatDataShouldReturnDataFromApiBecauseCacheD
 				PublicKey:       "pk1",
 				IsActive:        true,
 				ComputedShardID: 1,
+				ReceivedShardID: 1,
 			},
 			{
 				PublicKey:       "pk2",
 				IsActive:        true,
 				ComputedShardID: 0,
+				ReceivedShardID: 0,
 			},
 			{
 				PublicKey:       "pk3",
 				IsActive:        true,
 				ComputedShardID: 1,
+				ReceivedShardID: 1,
+			},
+			{
+				PublicKey:       "pk4",
+				IsActive:        true,
+				ComputedShardID: 1,
+				ReceivedShardID: 0,
 			},
 		},
 	}

--- a/process/heartbeatProcessor_test.go
+++ b/process/heartbeatProcessor_test.go
@@ -70,12 +70,12 @@ func TestHeartbeatProcessor_GetHeartbeatDataOkValuesShouldPass(t *testing.T) {
 			{
 				NodeDisplayName: "node0-1",
 				PublicKey:       "pk0-1",
-				ReceivedShardID: 0,
+				ComputedShardID: 0,
 			},
 			{
 				NodeDisplayName: "node0-2",
 				PublicKey:       "pk0-2",
-				ReceivedShardID: 0,
+				ComputedShardID: 0,
 			},
 		},
 	}
@@ -85,7 +85,7 @@ func TestHeartbeatProcessor_GetHeartbeatDataOkValuesShouldPass(t *testing.T) {
 			{
 				NodeDisplayName: "node1-1",
 				PublicKey:       "pk1-1",
-				ReceivedShardID: 1,
+				ComputedShardID: 1,
 			},
 		},
 	}
@@ -96,18 +96,18 @@ func TestHeartbeatProcessor_GetHeartbeatDataOkValuesShouldPass(t *testing.T) {
 				// duplicate from shard 0
 				NodeDisplayName: "node0-1",
 				PublicKey:       "pk0-1",
-				ReceivedShardID: 0,
+				ComputedShardID: 0,
 			},
 			{
 				// duplicate from shard 1
 				NodeDisplayName: "node1-1",
 				PublicKey:       "pk1-1",
-				ReceivedShardID: 1,
+				ComputedShardID: 1,
 			},
 			{
 				NodeDisplayName: "node2-1",
 				PublicKey:       "pk2-1",
-				ReceivedShardID: 2,
+				ComputedShardID: 2,
 			},
 		},
 	}
@@ -156,22 +156,22 @@ func TestHeartbeatProcessor_GetHeartbeatDataOkValuesShouldPass(t *testing.T) {
 		{
 			NodeDisplayName: "node0-1",
 			PublicKey:       "pk0-1",
-			ReceivedShardID: 0,
+			ComputedShardID: 0,
 		},
 		{
 			NodeDisplayName: "node0-2",
 			PublicKey:       "pk0-2",
-			ReceivedShardID: 0,
+			ComputedShardID: 0,
 		},
 		{
 			NodeDisplayName: "node1-1",
 			PublicKey:       "pk1-1",
-			ReceivedShardID: 1,
+			ComputedShardID: 1,
 		},
 		{
 			NodeDisplayName: "node2-1",
 			PublicKey:       "pk2-1",
-			ReceivedShardID: 2,
+			ComputedShardID: 2,
 		},
 	}
 


### PR DESCRIPTION
After shuffle out, the computedShard is the old shard, but receivedShard is the old one. Added checks in order to handle both situations, also added check to avoid overriding messages with invalid hearbeat v1 ones.