### PR TITLE
hotfix: nodes slice copy fixes

### DIFF
--- a/observer/circularQueueNodesProvider.go
+++ b/observer/circularQueueNodesProvider.go
@@ -47,7 +47,10 @@ func (cqnp *circularQueueNodesProvider) GetNodesByShardId(shardId uint32) ([]*da
 	position := cqnp.computeCounterForShard(shardId, uint32(len(nodesForShard)))
 	sliceToRet := append(nodesForShard[position:], nodesForShard[:position]...)
 
-	return sliceToRet, nil
+	copyOfSliceToRet := make([]*data.NodeData, len(sliceToRet))
+	copy(copyOfSliceToRet, sliceToRet)
+
+	return copyOfSliceToRet, nil
 }
 
 // GetAllNodes will return a slice containing all observers
@@ -60,7 +63,10 @@ func (cqnp *circularQueueNodesProvider) GetAllNodes() ([]*data.NodeData, error) 
 	position := cqnp.computeCounterForAllNodes(uint32(len(allNodes)))
 	sliceToRet := append(allNodes[position:], allNodes[:position]...)
 
-	return sliceToRet, nil
+	copyOfSliceToRet := make([]*data.NodeData, len(sliceToRet))
+	copy(copyOfSliceToRet, sliceToRet)
+
+	return copyOfSliceToRet, nil
 }
 
 func (cqnp *circularQueueNodesProvider) computeCounterForShard(shardID uint32, lenNodes uint32) uint32 {

--- a/observer/circularQueueNodesProvider_test.go
+++ b/observer/circularQueueNodesProvider_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ElrondNetwork/elrond-proxy-go/config"
 	"github.com/ElrondNetwork/elrond-proxy-go/data"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func getDummyConfig() config.Config {
@@ -131,6 +132,82 @@ func TestCircularQueueObserversProvider_GetAllObserversShouldWorkAndBalanceObser
 
 	res4, _ := cqop.GetAllNodes()
 	assert.Equal(t, res1, res4)
+}
+
+func TestCircularQueueNodesProvider_GetNodesByShardIdShouldReturnCopyOfSlice(t *testing.T) {
+	observers := []*data.NodeData{
+		{
+			Address: "addr1",
+			ShardId: 0,
+		},
+		{
+			Address: "addr2",
+			ShardId: 0,
+		},
+		{
+			Address: "addr3",
+			ShardId: 0,
+		},
+		{
+			Address: "addr4",
+			ShardId: 0,
+		},
+		{
+			Address: "addr5",
+			ShardId: 0,
+		},
+	}
+	cfg := config.Config{
+		Observers: observers,
+	}
+
+	cqnp, _ := NewCircularQueueNodesProvider(cfg.Observers, "path")
+
+	nodesInShard, _ := cqnp.GetNodesByShardId(0)
+
+	cqnp.nodesMap[0][3] = nil
+
+	for idx, node := range nodesInShard {
+		require.NotNil(t, node, "node with index %d is nil", idx)
+	}
+}
+
+func TestCircularQueueNodesProvider_GetAllNodesShouldReturnCopy(t *testing.T) {
+	observers := []*data.NodeData{
+		{
+			Address: "addr1",
+			ShardId: 0,
+		},
+		{
+			Address: "addr2",
+			ShardId: 0,
+		},
+		{
+			Address: "addr3",
+			ShardId: 0,
+		},
+		{
+			Address: "addr4",
+			ShardId: 0,
+		},
+		{
+			Address: "addr5",
+			ShardId: 0,
+		},
+	}
+	cfg := config.Config{
+		Observers: observers,
+	}
+
+	cqnp, _ := NewCircularQueueNodesProvider(cfg.Observers, "path")
+
+	nodesInShard, _ := cqnp.GetAllNodes()
+
+	cqnp.syncedNodes[3] = nil
+
+	for idx, node := range nodesInShard {
+		require.NotNil(t, node, "node with index %d is nil", idx)
+	}
 }
 
 func TestCircularQueueObserversProvider_GetAllObservers_ConcurrentSafe(t *testing.T) {

--- a/observer/simpleNodesProvider.go
+++ b/observer/simpleNodesProvider.go
@@ -36,7 +36,10 @@ func (snp *simpleNodesProvider) GetNodesByShardId(shardId uint32) ([]*data.NodeD
 		return nil, ErrShardNotAvailable
 	}
 
-	return nodesForShard, nil
+	copyOfSliceToRet := make([]*data.NodeData, len(nodesForShard))
+	copy(copyOfSliceToRet, nodesForShard)
+
+	return copyOfSliceToRet, nil
 }
 
 // GetAllNodes will return a slice containing all the nodes
@@ -44,7 +47,10 @@ func (snp *simpleNodesProvider) GetAllNodes() ([]*data.NodeData, error) {
 	snp.mutNodes.RLock()
 	defer snp.mutNodes.RUnlock()
 
-	return snp.syncedNodes, nil
+	copyOfSliceToRet := make([]*data.NodeData, len(snp.syncedNodes))
+	copy(copyOfSliceToRet, snp.syncedNodes)
+
+	return copyOfSliceToRet, nil
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/observer/simpleNodesProvider_test.go
+++ b/observer/simpleNodesProvider_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ElrondNetwork/elrond-proxy-go/config"
 	"github.com/ElrondNetwork/elrond-proxy-go/data"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewSimpleObserversProvider_EmptyObserversListShouldErr(t *testing.T) {
@@ -126,6 +127,82 @@ func TestSimpleObserversProvider_GetObserversByShardId_ConcurrentSafe(t *testing
 		assert.Equal(t, expectedNumOfTimesAnObserverIsCalled, res)
 	}
 	mutMap.RUnlock()
+}
+
+func TestSimpleNodesProvider_GetNodesByShardIdShouldReturnCopyOfSlice(t *testing.T) {
+	observers := []*data.NodeData{
+		{
+			Address: "addr1",
+			ShardId: 0,
+		},
+		{
+			Address: "addr2",
+			ShardId: 0,
+		},
+		{
+			Address: "addr3",
+			ShardId: 0,
+		},
+		{
+			Address: "addr4",
+			ShardId: 0,
+		},
+		{
+			Address: "addr5",
+			ShardId: 0,
+		},
+	}
+	cfg := config.Config{
+		Observers: observers,
+	}
+
+	cqnp, _ := NewSimpleNodesProvider(cfg.Observers, "path")
+
+	nodesInShard, _ := cqnp.GetNodesByShardId(0)
+
+	cqnp.nodesMap[0][3] = nil
+
+	for idx, node := range nodesInShard {
+		require.NotNil(t, node, "node with index %d is nil", idx)
+	}
+}
+
+func TestSimpleNodesProvider_GetAllNodesShouldReturnCopy(t *testing.T) {
+	observers := []*data.NodeData{
+		{
+			Address: "addr1",
+			ShardId: 0,
+		},
+		{
+			Address: "addr2",
+			ShardId: 0,
+		},
+		{
+			Address: "addr3",
+			ShardId: 0,
+		},
+		{
+			Address: "addr4",
+			ShardId: 0,
+		},
+		{
+			Address: "addr5",
+			ShardId: 0,
+		},
+	}
+	cfg := config.Config{
+		Observers: observers,
+	}
+
+	cqnp, _ := NewSimpleNodesProvider(cfg.Observers, "path")
+
+	nodesInShard, _ := cqnp.GetAllNodes()
+
+	cqnp.syncedNodes[3] = nil
+
+	for idx, node := range nodesInShard {
+		require.NotNil(t, node, "node with index %d is nil", idx)
+	}
 }
 
 func TestSimpleObserversProvider_GetAllObservers_ConcurrentSafe(t *testing.T) {


### PR DESCRIPTION
copy the slice before returning it, since the values could be modified by the periodic nodes checks