### PR TITLE
Added option to parse hyperblock with txs finalized at source

### DIFF
--- a/api/groups/urlParams.go
+++ b/api/groups/urlParams.go
@@ -28,7 +28,12 @@ func parseHyperblockQueryOptions(c *gin.Context) (common.HyperblockQueryOptions,
 		return common.HyperblockQueryOptions{}, err
 	}
 
-	options := common.HyperblockQueryOptions{WithLogs: withLogs}
+	notarizedAtSource, err := parseBoolUrlParam(c, common.UrlParameterNotarizedAtSource)
+	if err != nil {
+		return common.HyperblockQueryOptions{}, err
+	}
+
+	options := common.HyperblockQueryOptions{WithLogs: withLogs, NotarizedAtSource: notarizedAtSource}
 	return options, nil
 }
 

--- a/common/options.go
+++ b/common/options.go
@@ -10,6 +10,8 @@ const (
 	UrlParameterWithTransactions = "withTxs"
 	// UrlParameterWithLogs represents the name of an URL parameter
 	UrlParameterWithLogs = "withLogs"
+	// UrlParameterNotarizedAtSource represents the name of an URL parameter
+	UrlParameterNotarizedAtSource = "notarized-at-source"
 	// UrlParameterOnFinalBlock represents the name of an URL parameter
 	UrlParameterOnFinalBlock = "onFinalBlock"
 	// UrlParameterOnStartOfEpoch represents the name of an URL parameter
@@ -38,7 +40,8 @@ type BlockQueryOptions struct {
 
 // HyperblockQueryOptions holds options for hyperblock queries
 type HyperblockQueryOptions struct {
-	WithLogs bool
+	WithLogs          bool
+	NotarizedAtSource bool
 }
 
 // TransactionQueryOptions holds options for transaction queries

--- a/common/options.go
+++ b/common/options.go
@@ -11,7 +11,7 @@ const (
 	// UrlParameterWithLogs represents the name of an URL parameter
 	UrlParameterWithLogs = "withLogs"
 	// UrlParameterNotarizedAtSource represents the name of an URL parameter
-	UrlParameterNotarizedAtSource = "notarized-at-source"
+	UrlParameterNotarizedAtSource = "notarizedAtSource"
 	// UrlParameterOnFinalBlock represents the name of an URL parameter
 	UrlParameterOnFinalBlock = "onFinalBlock"
 	// UrlParameterOnStartOfEpoch represents the name of an URL parameter

--- a/process/blockProcessor.go
+++ b/process/blockProcessor.go
@@ -118,7 +118,7 @@ func (bp *BlockProcessor) getObserversOrFullHistoryNodes(shardID uint32) ([]*dat
 
 // GetHyperBlockByHash returns the hyperblock by hash
 func (bp *BlockProcessor) GetHyperBlockByHash(hash string, options common.HyperblockQueryOptions) (*data.HyperblockApiResponse, error) {
-	builder := &HyperblockBuilder{}
+	builder := &hyperblockBuilder{}
 
 	blockQueryOptions := common.BlockQueryOptions{
 		WithTransactions: true,
@@ -142,13 +142,13 @@ func (bp *BlockProcessor) GetHyperBlockByHash(hash string, options common.Hyperb
 		builder.addShardBlock(&shardBlockResponse.Data.Block)
 	}
 
-	hyperblock := builder.build()
+	hyperblock := builder.build(options.NotarizedAtSource)
 	return data.NewHyperblockApiResponse(hyperblock), nil
 }
 
 // GetHyperBlockByNonce returns the hyperblock by nonce
 func (bp *BlockProcessor) GetHyperBlockByNonce(nonce uint64, options common.HyperblockQueryOptions) (*data.HyperblockApiResponse, error) {
-	builder := &HyperblockBuilder{}
+	builder := &hyperblockBuilder{}
 
 	blockQueryOptions := common.BlockQueryOptions{
 		WithTransactions: true,
@@ -172,7 +172,7 @@ func (bp *BlockProcessor) GetHyperBlockByNonce(nonce uint64, options common.Hype
 		builder.addShardBlock(&shardBlockResponse.Data.Block)
 	}
 
-	hyperblock := builder.build()
+	hyperblock := builder.build(options.NotarizedAtSource)
 	return data.NewHyperblockApiResponse(hyperblock), nil
 }
 

--- a/process/hyperblockBuilder.go
+++ b/process/hyperblockBuilder.go
@@ -6,26 +6,26 @@ import (
 	"github.com/ElrondNetwork/elrond-proxy-go/data"
 )
 
-type HyperblockBuilder struct {
+type hyperblockBuilder struct {
 	metaBlock   *api.Block
 	shardBlocks []*api.Block
 }
 
-func (builder *HyperblockBuilder) addMetaBlock(metablock *api.Block) {
+func (builder *hyperblockBuilder) addMetaBlock(metablock *api.Block) {
 	builder.metaBlock = metablock
 }
 
-func (builder *HyperblockBuilder) addShardBlock(block *api.Block) {
+func (builder *hyperblockBuilder) addShardBlock(block *api.Block) {
 	builder.shardBlocks = append(builder.shardBlocks, block)
 }
 
-func (builder *HyperblockBuilder) build() data.Hyperblock {
+func (builder *hyperblockBuilder) build(notarizedAtSource bool) data.Hyperblock {
 	hyperblock := data.Hyperblock{}
 	bunch := newBunchOfTxs()
 
-	bunch.collectTxs(builder.metaBlock)
+	bunch.collectTxs(builder.metaBlock, notarizedAtSource)
 	for _, block := range builder.shardBlocks {
-		bunch.collectTxs(block)
+		bunch.collectTxs(block, notarizedAtSource)
 	}
 
 	hyperblock.Nonce = builder.metaBlock.Nonce
@@ -59,14 +59,35 @@ func newBunchOfTxs() *bunchOfTxs {
 	}
 }
 
-// In a hyperblock we only return transactions that are fully executed (in both shards).
+// In a hyperblock we only return transactions that are fully executed (in both shards), if the notarizedAtSource isn't enabled.
 // Furthermore, we ignore miniblocks of type "PeerBlock"
-func (bunch *bunchOfTxs) collectTxs(block *api.Block) {
+func (bunch *bunchOfTxs) collectTxs(block *api.Block, notarizedAtSource bool) {
+	if notarizedAtSource {
+		bunch.collectNotarizedAtSourceTxs(block)
+		return
+	}
+
+	bunch.collectFinalizedTxs(block)
+}
+
+func (bunch *bunchOfTxs) collectFinalizedTxs(block *api.Block) {
 	for _, miniBlock := range block.MiniBlocks {
 		isPeerMiniBlock := miniBlock.Type == "PeerBlock"
 		isExecutedOnDestination := miniBlock.DestinationShard == block.Shard
 
 		shouldCollect := !isPeerMiniBlock && isExecutedOnDestination
+		if shouldCollect {
+			bunch.txs = append(bunch.txs, miniBlock.Transactions...)
+		}
+	}
+}
+
+func (bunch *bunchOfTxs) collectNotarizedAtSourceTxs(block *api.Block) {
+	for _, miniBlock := range block.MiniBlocks {
+		isPeerMiniBlock := miniBlock.Type == "PeerBlock"
+		isNotarizedAtSource := miniBlock.SourceShard == block.Shard
+
+		shouldCollect := !isPeerMiniBlock && isNotarizedAtSource
 		if shouldCollect {
 			bunch.txs = append(bunch.txs, miniBlock.Transactions...)
 		}

--- a/process/hyperblockBuilder_test.go
+++ b/process/hyperblockBuilder_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestHyperblockBuilder(t *testing.T) {
-	builder := &HyperblockBuilder{}
+func TestHyperblockBuilderWithFinalizedTxs(t *testing.T) {
+	builder := &hyperblockBuilder{}
 
 	builder.addMetaBlock(&api.Block{Shard: 4294967295, Nonce: 42, Timestamp: time.Duration(12345), MiniBlocks: []*api.MiniBlock{
 		{SourceShard: 4294967295, DestinationShard: 0, Transactions: []*transaction.ApiTransactionResult{
@@ -48,7 +48,7 @@ func TestHyperblockBuilder(t *testing.T) {
 		}},
 	}})
 
-	hyperblock := builder.build()
+	hyperblock := builder.build(false)
 
 	require.Equal(t, 42, int(hyperblock.Nonce))
 	require.Equal(t, 4, int(hyperblock.NumTxs))
@@ -58,6 +58,59 @@ func TestHyperblockBuilder(t *testing.T) {
 		{Sender: "alice", Receiver: "stakingContract"},
 		{Sender: "alice", Receiver: "bob"},
 		{Sender: "alice", Receiver: "carol"},
+		{Sender: "carol", Receiver: "carol"},
+	}, hyperblock.Transactions)
+}
+
+func TestHyperblockBuilderWithNotarizedAtSourceTxs(t *testing.T) {
+	builder := &hyperblockBuilder{}
+
+	builder.addMetaBlock(&api.Block{Shard: 4294967295, Nonce: 42, Timestamp: time.Duration(12345), MiniBlocks: []*api.MiniBlock{
+		{SourceShard: 4294967295, DestinationShard: 0, Transactions: []*transaction.ApiTransactionResult{
+			{Sender: "metachain", Receiver: "alice"},
+		}},
+		{SourceShard: 4294967295, DestinationShard: 1, Transactions: []*transaction.ApiTransactionResult{
+			{Sender: "staking-contract", Receiver: "carol"},
+		}},
+		{SourceShard: 0, DestinationShard: 4294967295, Transactions: []*transaction.ApiTransactionResult{
+			{Sender: "alice", Receiver: "stakingContract"},
+		}},
+	}, NotarizedBlocks: []*api.NotarizedBlock{
+		{Shard: 0, Nonce: 40},
+		{Shard: 1, Nonce: 41},
+	}})
+
+	builder.addShardBlock(&api.Block{Shard: 0, Nonce: 40, MiniBlocks: []*api.MiniBlock{
+		{SourceShard: 0, DestinationShard: 0, Transactions: []*transaction.ApiTransactionResult{
+			{Sender: "alice", Receiver: "bob"},
+		}},
+		{SourceShard: 1, DestinationShard: 0, Transactions: []*transaction.ApiTransactionResult{
+			{Sender: "alice", Receiver: "carol"},
+		}},
+	}})
+
+	builder.addShardBlock(&api.Block{Shard: 1, Nonce: 41, MiniBlocks: []*api.MiniBlock{
+		{SourceShard: 0, DestinationShard: 1, Transactions: []*transaction.ApiTransactionResult{
+			{Sender: "alice", Receiver: "carol"},
+		}},
+		{SourceShard: 1, DestinationShard: 1, Transactions: []*transaction.ApiTransactionResult{
+			{Sender: "carol", Receiver: "carol"},
+		}},
+		{SourceShard: 1, DestinationShard: 1, Type: "PeerBlock", Transactions: []*transaction.ApiTransactionResult{
+			{Sender: "foo", Receiver: "bar"},
+		}},
+	}})
+
+	hyperblock := builder.build(true)
+
+	require.Equal(t, 42, int(hyperblock.Nonce))
+	require.Equal(t, 4, int(hyperblock.NumTxs))
+	require.Equal(t, 2, len(hyperblock.ShardBlocks))
+	require.Equal(t, time.Duration(12345), hyperblock.Timestamp)
+	require.Equal(t, []*transaction.ApiTransactionResult{
+		{Sender: "metachain", Receiver: "alice"},
+		{Sender: "staking-contract", Receiver: "carol"},
+		{Sender: "alice", Receiver: "bob"},
 		{Sender: "carol", Receiver: "carol"},
 	}, hyperblock.Transactions)
 }


### PR DESCRIPTION
Added the `?notarizedAtSource=true` option so the resulting hyperblock will only contain transactions that have been notarized at source, as opposed to the original hyperblock that only returned transactions notarized at destination

**Testing procedure**:
- on a testnet use this proxy branch
- find a metablock that has notarized shard headers
- query `<proxy-url>:<proxy-port>/hyperblock/by-nonce/<nonce from previous step>?notarizedAtSource=true` and you should only see transactions that are not mandatory final (for cross-check, you can see that one of the transactions was only executed on source, while the destination execution was at a later time)
- query without the `?notarizedAtSource=true` and/or with `?notarizedAtSource=false` and only finalized transaction should be seen