### PR TITLE
Protocol tx fields

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/ElrondNetwork/elastic-indexer-go v1.2.30
 	github.com/ElrondNetwork/elrond-go v1.3.27
-	github.com/ElrondNetwork/elrond-go-core v1.1.18
+	github.com/ElrondNetwork/elrond-go-core v1.1.21-0.20221018135819-929c00fc000d
 	github.com/ElrondNetwork/elrond-go-crypto v1.0.1
 	github.com/ElrondNetwork/elrond-go-logger v1.0.7
 	github.com/elastic/go-elasticsearch/v7 v7.12.0

--- a/go.sum
+++ b/go.sum
@@ -60,8 +60,8 @@ github.com/ElrondNetwork/elrond-go-core v1.1.6/go.mod h1:O9FkkTT2H9kxCzfn40TbhoC
 github.com/ElrondNetwork/elrond-go-core v1.1.7/go.mod h1:O9FkkTT2H9kxCzfn40TbhoCDXzGmUrRVusMomhK/Y3g=
 github.com/ElrondNetwork/elrond-go-core v1.1.14/go.mod h1:Yz8JK5sGBctw7+gU8j2mZHbzQ09Ek4XHJ4Uinq1N6nM=
 github.com/ElrondNetwork/elrond-go-core v1.1.15/go.mod h1:Yz8JK5sGBctw7+gU8j2mZHbzQ09Ek4XHJ4Uinq1N6nM=
-github.com/ElrondNetwork/elrond-go-core v1.1.18 h1:qFxroKtZlT+I8OtuhsBoBRv77rk18JnpzOl0q0fqZK0=
-github.com/ElrondNetwork/elrond-go-core v1.1.18/go.mod h1:Yz8JK5sGBctw7+gU8j2mZHbzQ09Ek4XHJ4Uinq1N6nM=
+github.com/ElrondNetwork/elrond-go-core v1.1.21-0.20221018135819-929c00fc000d h1:Hfa/AA14pOhDzt2SCocfEdDkUDQFAcJp4Bp3wiUvhLw=
+github.com/ElrondNetwork/elrond-go-core v1.1.21-0.20221018135819-929c00fc000d/go.mod h1:Yz8JK5sGBctw7+gU8j2mZHbzQ09Ek4XHJ4Uinq1N6nM=
 github.com/ElrondNetwork/elrond-go-crypto v1.0.0/go.mod h1:DGiR7/j1xv729Xg8SsjYaUzWXL5svMd44REXjWS/gAc=
 github.com/ElrondNetwork/elrond-go-crypto v1.0.1 h1:xJUUshIZQ7h+rG7Art/9QHVyaPRV1wEjrxXYBdpmRlM=
 github.com/ElrondNetwork/elrond-go-crypto v1.0.1/go.mod h1:uunsvweBrrhVojL8uiQSaTPsl3YIQ9iBqtYGM6xs4s0=


### PR DESCRIPTION
When querying for `ApiTransactionResult` (either in block/proxy hyperblock), some protocol transaction+scr fields were missing. Some of them were mandatory for external clients to re-create protocol transactiom(e.g. validate transaction signature based on transaction version + options). 
Updated go mod to add support for missing fields