### PR TITLE
Altered accounts in hyper block

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,9 @@ Please note that `altered-accounts` endpoints will only work if the backing obse
 ### hyperblock
 
 - `/v1.0/hyperblock/by-nonce/:nonce`  (GET) --> returns a hyperblock by nonce, with transactions included
+- `/v1.0/hyperblock/by-nonce/:nonce?withAlteredAccounts=true`  (GET) --> returns a hyperblock by nonce, with transactions and altered accounts in each notarized block. Other available query parameters are `&tokens=token1,token2&withMetadata=true` as described in the `block` section above
 - `/v1.0/hyperblock/by-hash/:hash`    (GET) --> returns a hyperblock by hash, with transactions included
+- `/v1.0/hyperblock/by-hash/:hash?withAlteredAccounts=true`  (GET) --> returns a hyperblock by hash, with transactions and altered accounts in each notarized block. Other available query parameters are `&tokens=token1,token2&withMetadata=true` as described in the `block` section above
 
 # V_next
 

--- a/api/groups/urlParams.go
+++ b/api/groups/urlParams.go
@@ -34,8 +34,25 @@ func parseHyperblockQueryOptions(c *gin.Context) (common.HyperblockQueryOptions,
 		return common.HyperblockQueryOptions{}, err
 	}
 
-	options := common.HyperblockQueryOptions{WithLogs: withLogs, NotarizedAtSource: notarizedAtSource}
-	return options, nil
+	withAlteredAccounts, err := parseBoolUrlParam(c, common.UrlParameterWithAlteredAccounts)
+	if err != nil {
+		return common.HyperblockQueryOptions{}, err
+	}
+
+	var alteredAccountsOptions common.GetAlteredAccountsForBlockOptions
+	if withAlteredAccounts {
+		alteredAccountsOptions, err = parseAlteredAccountOptions(c)
+		if err != nil {
+			return common.HyperblockQueryOptions{}, err
+		}
+	}
+
+	return common.HyperblockQueryOptions{
+		WithLogs:               withLogs,
+		NotarizedAtSource:      notarizedAtSource,
+		WithAlteredAccounts:    withAlteredAccounts,
+		AlteredAccountsOptions: alteredAccountsOptions,
+	}, nil
 }
 
 func parseAccountQueryOptions(c *gin.Context) (common.AccountQueryOptions, error) {

--- a/api/groups/urlParams_test.go
+++ b/api/groups/urlParams_test.go
@@ -1,6 +1,7 @@
 package groups
 
 import (
+	"fmt"
 	"net/http"
 	"net/url"
 	"testing"
@@ -26,17 +27,101 @@ func TestParseBlockQueryOptions(t *testing.T) {
 }
 
 func TestParseHyperblockQueryOptions(t *testing.T) {
-	options, err := parseHyperblockQueryOptions(createDummyGinContextWithQuery("withLogs=true"))
-	require.Nil(t, err)
-	require.Equal(t, common.HyperblockQueryOptions{WithLogs: true}, options)
+	t.Parallel()
 
-	options, err = parseHyperblockQueryOptions(createDummyGinContextWithQuery(""))
-	require.Nil(t, err)
-	require.Empty(t, options)
+	t.Run("empty query, should return error", func(t *testing.T) {
+		t.Parallel()
 
-	options, err = parseHyperblockQueryOptions(createDummyGinContextWithQuery("withLogs=foobar"))
-	require.NotNil(t, err)
-	require.Empty(t, options)
+		query := ""
+		options, err := parseHyperblockQueryOptions(createDummyGinContextWithQuery(query))
+		require.Nil(t, err)
+		require.Empty(t, options)
+	})
+
+	t.Run("invalid withLogs param, should return error", func(t *testing.T) {
+		t.Parallel()
+
+		query := fmt.Sprintf("%s=foobar", common.UrlParameterWithLogs)
+		options, err := parseHyperblockQueryOptions(createDummyGinContextWithQuery(query))
+		require.NotNil(t, err)
+		require.Empty(t, options)
+	})
+
+	t.Run("invalid notarizedAtSource param, should return error", func(t *testing.T) {
+		t.Parallel()
+
+		query := fmt.Sprintf("%s=foobar", common.UrlParameterNotarizedAtSource)
+		options, err := parseHyperblockQueryOptions(createDummyGinContextWithQuery(query))
+		require.NotNil(t, err)
+		require.Empty(t, options)
+	})
+
+	t.Run("invalid withAlteredAccounts param, should return error", func(t *testing.T) {
+		t.Parallel()
+
+		query := fmt.Sprintf("%s=foobar", common.UrlParameterWithAlteredAccounts)
+		options, err := parseHyperblockQueryOptions(createDummyGinContextWithQuery(query))
+		require.NotNil(t, err)
+		require.Empty(t, options)
+	})
+
+	t.Run("could not parse withAlteredAccounts params, should return error", func(t *testing.T) {
+		t.Parallel()
+
+		query := fmt.Sprintf("%s=true&%s=true",
+			common.UrlParameterWithAlteredAccounts,
+			common.UrlParameterWithMetadata,
+		)
+		options, err := parseHyperblockQueryOptions(createDummyGinContextWithQuery(query))
+		require.Equal(t, errors.ErrIncompatibleWithMetadataParam, err)
+		require.Empty(t, options)
+	})
+
+	t.Run("with logs", func(t *testing.T) {
+		t.Parallel()
+
+		query := fmt.Sprintf("%s=true", common.UrlParameterWithLogs)
+		options, err := parseHyperblockQueryOptions(createDummyGinContextWithQuery(query))
+		require.Nil(t, err)
+		require.Equal(t, common.HyperblockQueryOptions{WithLogs: true}, options)
+	})
+
+	t.Run("notarized at source", func(t *testing.T) {
+		t.Parallel()
+
+		query := fmt.Sprintf("%s=true", common.UrlParameterNotarizedAtSource)
+		options, err := parseHyperblockQueryOptions(createDummyGinContextWithQuery(query))
+		require.Nil(t, err)
+		require.Equal(t, common.HyperblockQueryOptions{NotarizedAtSource: true}, options)
+	})
+
+	t.Run("with altered accounts", func(t *testing.T) {
+		t.Parallel()
+
+		query := fmt.Sprintf("%s=true", common.UrlParameterWithAlteredAccounts)
+		options, err := parseHyperblockQueryOptions(createDummyGinContextWithQuery(query))
+		require.Nil(t, err)
+		require.Equal(t, common.HyperblockQueryOptions{WithAlteredAccounts: true}, options)
+	})
+
+	t.Run("with altered accounts and query params", func(t *testing.T) {
+		t.Parallel()
+
+		query := fmt.Sprintf("%s=true&%s=*&%s=true",
+			common.UrlParameterWithAlteredAccounts,
+			common.UrlParameterTokensFilter,
+			common.UrlParameterWithMetadata,
+		)
+		options, err := parseHyperblockQueryOptions(createDummyGinContextWithQuery(query))
+		require.Nil(t, err)
+		require.Equal(t, common.HyperblockQueryOptions{
+			WithAlteredAccounts: true,
+			AlteredAccountsOptions: common.GetAlteredAccountsForBlockOptions{
+				TokensFilter: "*",
+				WithMetadata: true,
+			},
+		}, options)
+	})
 }
 
 func TestParseAccountQueryOptions(t *testing.T) {

--- a/common/options.go
+++ b/common/options.go
@@ -34,6 +34,8 @@ const (
 	UrlParameterWithMetadata = "withMetadata"
 	// UrlParameterTokensFilter represents the name of an URL parameter
 	UrlParameterTokensFilter = "tokens"
+	// UrlParameterWithAlteredAccounts represents the name of an URL parameter
+	UrlParameterWithAlteredAccounts = "withAlteredAccounts"
 )
 
 // BlockQueryOptions holds options for block queries
@@ -44,8 +46,10 @@ type BlockQueryOptions struct {
 
 // HyperblockQueryOptions holds options for hyperblock queries
 type HyperblockQueryOptions struct {
-	WithLogs          bool
-	NotarizedAtSource bool
+	WithLogs               bool
+	NotarizedAtSource      bool
+	WithAlteredAccounts    bool
+	AlteredAccountsOptions GetAlteredAccountsForBlockOptions
 }
 
 // TransactionQueryOptions holds options for transaction queries

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/ElrondNetwork/elastic-indexer-go v1.2.44-0.20221006131929-a7c3dec53ba1
 	github.com/ElrondNetwork/elrond-go v1.3.45-0.20221020085243-978bf0f08a13
-	github.com/ElrondNetwork/elrond-go-core v1.1.21-0.20221007124718-8c58913e9f35
+	github.com/ElrondNetwork/elrond-go-core v1.1.24-0.20221027085544-81e442aed8e0
 	github.com/ElrondNetwork/elrond-go-crypto v1.2.1
 	github.com/ElrondNetwork/elrond-go-logger v1.0.8
 	github.com/elastic/go-elasticsearch/v7 v7.12.0

--- a/go.sum
+++ b/go.sum
@@ -59,8 +59,9 @@ github.com/ElrondNetwork/elrond-go-core v1.1.19-0.20220729074346-fca5b87ec7c7/go
 github.com/ElrondNetwork/elrond-go-core v1.1.19/go.mod h1:Yz8JK5sGBctw7+gU8j2mZHbzQ09Ek4XHJ4Uinq1N6nM=
 github.com/ElrondNetwork/elrond-go-core v1.1.20-0.20220915145036-720d0233becd/go.mod h1:UcZAiUqKBv3M3U6pJkYqIAx4OKubLYIc0QBVN+bY29g=
 github.com/ElrondNetwork/elrond-go-core v1.1.21-0.20221006120212-5c0ba882cdd0/go.mod h1:UcZAiUqKBv3M3U6pJkYqIAx4OKubLYIc0QBVN+bY29g=
-github.com/ElrondNetwork/elrond-go-core v1.1.21-0.20221007124718-8c58913e9f35 h1:ZVPD/Z5NYK53RA7sXYMoO30dUVTCOT94FWafOdothTo=
 github.com/ElrondNetwork/elrond-go-core v1.1.21-0.20221007124718-8c58913e9f35/go.mod h1:UcZAiUqKBv3M3U6pJkYqIAx4OKubLYIc0QBVN+bY29g=
+github.com/ElrondNetwork/elrond-go-core v1.1.24-0.20221027085544-81e442aed8e0 h1:bPVN39UTuE+a/f/wyz4qrKzF0GVeUtKDXaJNXk4YlkA=
+github.com/ElrondNetwork/elrond-go-core v1.1.24-0.20221027085544-81e442aed8e0/go.mod h1:UcZAiUqKBv3M3U6pJkYqIAx4OKubLYIc0QBVN+bY29g=
 github.com/ElrondNetwork/elrond-go-crypto v1.0.0/go.mod h1:DGiR7/j1xv729Xg8SsjYaUzWXL5svMd44REXjWS/gAc=
 github.com/ElrondNetwork/elrond-go-crypto v1.2.1 h1:5wWCBEZp5SMFO2+Nal8UaJNJcG9G9J4PHNNZvQpEeUE=
 github.com/ElrondNetwork/elrond-go-crypto v1.2.1/go.mod h1:UNmpDaJjLTKxfzUcwua2R7Mh9bicw/L3ICJt5V7zqMo=

--- a/process/blockProcessor.go
+++ b/process/blockProcessor.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ElrondNetwork/elrond-go-core/core"
 	"github.com/ElrondNetwork/elrond-go-core/core/check"
+	"github.com/ElrondNetwork/elrond-go-core/data/api"
 	"github.com/ElrondNetwork/elrond-proxy-go/common"
 	"github.com/ElrondNetwork/elrond-proxy-go/data"
 )
@@ -136,17 +137,42 @@ func (bp *BlockProcessor) GetHyperBlockByHash(hash string, options common.Hyperb
 	metaBlock := metaBlockResponse.Data.Block
 	builder.addMetaBlock(&metaBlock)
 
-	for _, notarizedBlock := range metaBlock.NotarizedBlocks {
-		shardBlockResponse, err := bp.GetBlockByHash(notarizedBlock.Shard, notarizedBlock.Hash, blockQueryOptions)
-		if err != nil {
-			return nil, err
-		}
-
-		builder.addShardBlock(&shardBlockResponse.Data.Block)
+	err = bp.addShardBlocks(metaBlock, builder, options, blockQueryOptions)
+	if err != nil {
+		return nil, err
 	}
 
 	hyperblock := builder.build(options.NotarizedAtSource)
 	return data.NewHyperblockApiResponse(hyperblock), nil
+}
+
+func (bp *BlockProcessor) addShardBlocks(
+	metaBlock api.Block,
+	builder *hyperblockBuilder,
+	options common.HyperblockQueryOptions,
+	blockQueryOptions common.BlockQueryOptions,
+) error {
+	for _, notarizedBlock := range metaBlock.NotarizedBlocks {
+		shardBlockWithAccounts := &shardBlockWithAlteredAccounts{}
+		shardBlockResponse, err := bp.GetBlockByHash(notarizedBlock.Shard, notarizedBlock.Hash, blockQueryOptions)
+		if err != nil {
+			return err
+		}
+		shardBlockWithAccounts.shardBlock = &shardBlockResponse.Data.Block
+
+		if options.WithAlteredAccounts {
+			alteredAccountsApiResponse, err := bp.GetAlteredAccountsByHash(notarizedBlock.Shard, notarizedBlock.Hash, options.AlteredAccountsOptions)
+			if err != nil {
+				return err
+			}
+
+			shardBlockWithAccounts.alteredAccounts = alteredAccountsApiResponse.Data.Accounts
+		}
+
+		builder.addShardBlock(shardBlockWithAccounts)
+	}
+
+	return nil
 }
 
 // GetHyperBlockByNonce returns the hyperblock by nonce
@@ -166,13 +192,9 @@ func (bp *BlockProcessor) GetHyperBlockByNonce(nonce uint64, options common.Hype
 	metaBlock := metaBlockResponse.Data.Block
 	builder.addMetaBlock(&metaBlock)
 
-	for _, notarizedBlock := range metaBlock.NotarizedBlocks {
-		shardBlockResponse, err := bp.GetBlockByHash(notarizedBlock.Shard, notarizedBlock.Hash, blockQueryOptions)
-		if err != nil {
-			return nil, err
-		}
-
-		builder.addShardBlock(&shardBlockResponse.Data.Block)
+	err = bp.addShardBlocks(metaBlock, builder, options, blockQueryOptions)
+	if err != nil {
+		return nil, err
 	}
 
 	hyperblock := builder.build(options.NotarizedAtSource)

--- a/process/blockProcessor_test.go
+++ b/process/blockProcessor_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go-core/core"
 	"github.com/ElrondNetwork/elrond-go-core/data/api"
 	"github.com/ElrondNetwork/elrond-go-core/data/outport"
+	"github.com/ElrondNetwork/elrond-go-core/data/transaction"
 	"github.com/ElrondNetwork/elrond-proxy-go/common"
 	"github.com/ElrondNetwork/elrond-proxy-go/data"
 	"github.com/ElrondNetwork/elrond-proxy-go/process"
@@ -1160,4 +1161,119 @@ func TestBlockProcessor_GetAlteredAccountsByHash(t *testing.T) {
 			Code:  "success",
 		}, res)
 	})
+}
+
+func TestBlockProcessor_GetHyperBlockByNonceWithAlteredAccounts(t *testing.T) {
+	t.Parallel()
+
+	observerAddr := "observerAddress"
+	alteredAcc1 := &outport.AlteredAccount{Address: "erd1q"}
+	alteredAcc2 := &outport.AlteredAccount{Address: "erd1w"}
+
+	callGetEndpointCt := 0
+	getObserversCt := 0
+	proc := &mock.ProcessorStub{
+		GetObserversCalled: func(shardId uint32) ([]*data.NodeData, error) {
+			switch getObserversCt {
+			case 0:
+				require.Equal(t, core.MetachainShardId, shardId)
+			case 1, 2:
+				require.Equal(t, uint32(1), shardId)
+			case 3, 4:
+				require.Equal(t, uint32(2), shardId)
+			}
+
+			getObserversCt++
+			return []*data.NodeData{{ShardId: shardId, Address: observerAddr}}, nil
+		},
+
+		CallGetRestEndPointCalled: func(address string, path string, value interface{}) (int, error) {
+			require.Equal(t, observerAddr, address)
+
+			switch callGetEndpointCt {
+			case 0:
+				require.Equal(t, &data.BlockApiResponse{}, value)
+				require.Equal(t, "/block/by-nonce/4?withTxs=true", path)
+
+				ret := value.(*data.BlockApiResponse)
+				ret.Code = data.ReturnCodeSuccess
+				ret.Data.Block = api.Block{
+					StateRootHash: "stateRootHash",
+					NotarizedBlocks: []*api.NotarizedBlock{
+						{
+							Shard: 1,
+							Hash:  "hash1",
+						},
+						{
+							Shard: 2,
+							Hash:  "hash2",
+						},
+					},
+				}
+			case 1:
+				require.Equal(t, &data.BlockApiResponse{}, value)
+				require.Equal(t, "/block/by-hash/hash1?withTxs=true", path)
+
+				ret := value.(*data.BlockApiResponse)
+				ret.Code = data.ReturnCodeSuccess
+				ret.Data.Block = api.Block{Hash: "hash1", Shard: 1}
+			case 2:
+				require.Equal(t, &data.AlteredAccountsApiResponse{}, value)
+				require.Equal(t, "/block/altered-accounts/by-hash/hash1", path)
+
+				ret := value.(*data.AlteredAccountsApiResponse)
+				ret.Code = data.ReturnCodeSuccess
+				ret.Data.Accounts = []*outport.AlteredAccount{alteredAcc1}
+			case 3:
+				require.Equal(t, &data.BlockApiResponse{}, value)
+				require.Equal(t, "/block/by-hash/hash2?withTxs=true", path)
+
+				ret := value.(*data.BlockApiResponse)
+				ret.Code = data.ReturnCodeSuccess
+				ret.Data.Block = api.Block{Hash: "hash2", Shard: 2}
+			case 4:
+				require.Equal(t, &data.AlteredAccountsApiResponse{}, value)
+				require.Equal(t, "/block/altered-accounts/by-hash/hash2", path)
+
+				ret := value.(*data.AlteredAccountsApiResponse)
+				ret.Code = data.ReturnCodeSuccess
+				ret.Data.Accounts = []*outport.AlteredAccount{alteredAcc2}
+			}
+
+			callGetEndpointCt++
+			return 0, nil
+		},
+	}
+
+	bp, _ := process.NewBlockProcessor(&mock.ExternalStorageConnectorStub{}, proc)
+
+	res, err := bp.GetHyperBlockByNonce(4, common.HyperblockQueryOptions{WithAlteredAccounts: true})
+	require.Nil(t, err)
+
+	expectedHyperBlock := data.Hyperblock{
+		StateRootHash: "stateRootHash",
+		ShardBlocks: []*api.NotarizedBlock{
+			{
+				Shard:           1,
+				Hash:            "hash1",
+				AlteredAccounts: []*outport.AlteredAccount{alteredAcc1},
+			},
+			{
+				Shard:           2,
+				Hash:            "hash2",
+				AlteredAccounts: []*outport.AlteredAccount{alteredAcc2},
+			},
+		},
+		Transactions: make([]*transaction.ApiTransactionResult, 0),
+	}
+
+	require.Equal(t, &data.HyperblockApiResponse{
+		Code: data.ReturnCodeSuccess,
+		Data: data.HyperblockApiResponsePayload{
+			Hyperblock: expectedHyperBlock,
+		},
+	}, res)
+	require.NotNil(t, res)
+	require.Equal(t, 5, callGetEndpointCt)
+	require.Equal(t, 5, getObserversCt)
 }

--- a/process/hyperblockBuilder.go
+++ b/process/hyperblockBuilder.go
@@ -57,13 +57,13 @@ func (builder *hyperblockBuilder) build(notarizedAtSource bool) data.Hyperblock 
 
 func (builder *hyperblockBuilder) buildShardBlocks() []*api.NotarizedBlock {
 	notarizedBlocks := make([]*api.NotarizedBlock, 0, len(builder.shardBlocksWithAlteredAccounts))
-	for _, shardBlock := range builder.shardBlocksWithAlteredAccounts {
+	for _, block := range builder.shardBlocksWithAlteredAccounts {
 		notarizedBlocks = append(notarizedBlocks, &api.NotarizedBlock{
-			Hash:            shardBlock.shardBlock.Hash,
-			Nonce:           shardBlock.shardBlock.Nonce,
-			Round:           shardBlock.shardBlock.Round,
-			Shard:           shardBlock.shardBlock.Shard,
-			AlteredAccounts: shardBlock.alteredAccounts,
+			Hash:            block.shardBlock.Hash,
+			Nonce:           block.shardBlock.Nonce,
+			Round:           block.shardBlock.Round,
+			Shard:           block.shardBlock.Shard,
+			AlteredAccounts: block.alteredAccounts,
 		})
 	}
 

--- a/process/hyperblockBuilder_test.go
+++ b/process/hyperblockBuilder_test.go
@@ -4,8 +4,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ElrondNetwork/elrond-go-core/core"
 	"github.com/ElrondNetwork/elrond-go-core/data/api"
+	"github.com/ElrondNetwork/elrond-go-core/data/outport"
 	"github.com/ElrondNetwork/elrond-go-core/data/transaction"
+	"github.com/ElrondNetwork/elrond-proxy-go/data"
 	"github.com/stretchr/testify/require"
 )
 
@@ -113,4 +116,79 @@ func TestHyperblockBuilderWithNotarizedAtSourceTxs(t *testing.T) {
 		{Sender: "alice", Receiver: "bob"},
 		{Sender: "carol", Receiver: "carol"},
 	}, hyperblock.Transactions)
+}
+
+func TestHyperblockBuilderWithAlteredAccounts(t *testing.T) {
+	builder := &hyperblockBuilder{}
+
+	builder.addMetaBlock(&api.Block{
+		Shard: core.MetachainShardId,
+		Nonce: 42,
+		NotarizedBlocks: []*api.NotarizedBlock{
+			{Shard: 0, Nonce: 40},
+			{Shard: 1, Nonce: 41},
+		},
+	})
+
+	builder.addShardBlock(&shardBlockWithAlteredAccounts{
+		shardBlock: &api.Block{
+			Shard: 0,
+			Nonce: 40,
+		},
+		alteredAccounts: []*outport.AlteredAccount{
+			{
+				Address: "alice",
+				Balance: "100",
+			},
+		},
+	})
+
+	builder.addShardBlock(&shardBlockWithAlteredAccounts{
+		shardBlock: &api.Block{
+			Shard: 1,
+			Nonce: 41,
+		},
+		alteredAccounts: []*outport.AlteredAccount{
+			{
+				Address: "bob",
+				Balance: "101",
+			},
+			{
+				Address: "carol",
+				Balance: "102",
+			},
+		},
+	})
+
+	hyperblock := builder.build(false)
+	require.Equal(t, data.Hyperblock{
+		Nonce:        42,
+		Transactions: make([]*transaction.ApiTransactionResult, 0),
+		ShardBlocks: []*api.NotarizedBlock{
+			{
+				Shard: 0,
+				Nonce: 40,
+				AlteredAccounts: []*outport.AlteredAccount{
+					{
+						Address: "alice",
+						Balance: "100",
+					},
+				},
+			},
+			{
+				Shard: 1,
+				Nonce: 41,
+				AlteredAccounts: []*outport.AlteredAccount{
+					{
+						Address: "bob",
+						Balance: "101",
+					},
+					{
+						Address: "carol",
+						Balance: "102",
+					},
+				},
+			},
+		},
+	}, hyperblock)
 }

--- a/process/hyperblockBuilder_test.go
+++ b/process/hyperblockBuilder_test.go
@@ -27,16 +27,16 @@ func TestHyperblockBuilderWithFinalizedTxs(t *testing.T) {
 		{Shard: 1, Nonce: 41},
 	}})
 
-	builder.addShardBlock(&api.Block{Shard: 0, Nonce: 40, MiniBlocks: []*api.MiniBlock{
+	builder.addShardBlock(&shardBlockWithAlteredAccounts{shardBlock: &api.Block{Shard: 0, Nonce: 40, MiniBlocks: []*api.MiniBlock{
 		{SourceShard: 0, DestinationShard: 0, Transactions: []*transaction.ApiTransactionResult{
 			{Sender: "alice", Receiver: "bob"},
 		}},
 		{SourceShard: 0, DestinationShard: 1, Transactions: []*transaction.ApiTransactionResult{
 			{Sender: "alice", Receiver: "carol"},
 		}},
-	}})
+	}}})
 
-	builder.addShardBlock(&api.Block{Shard: 1, Nonce: 41, MiniBlocks: []*api.MiniBlock{
+	builder.addShardBlock(&shardBlockWithAlteredAccounts{shardBlock: &api.Block{Shard: 1, Nonce: 41, MiniBlocks: []*api.MiniBlock{
 		{SourceShard: 0, DestinationShard: 1, Transactions: []*transaction.ApiTransactionResult{
 			{Sender: "alice", Receiver: "carol"},
 		}},
@@ -46,7 +46,7 @@ func TestHyperblockBuilderWithFinalizedTxs(t *testing.T) {
 		{SourceShard: 1, DestinationShard: 1, Type: "PeerBlock", Transactions: []*transaction.ApiTransactionResult{
 			{Sender: "foo", Receiver: "bar"},
 		}},
-	}})
+	}}})
 
 	hyperblock := builder.build(false)
 
@@ -80,16 +80,16 @@ func TestHyperblockBuilderWithNotarizedAtSourceTxs(t *testing.T) {
 		{Shard: 1, Nonce: 41},
 	}})
 
-	builder.addShardBlock(&api.Block{Shard: 0, Nonce: 40, MiniBlocks: []*api.MiniBlock{
+	builder.addShardBlock(&shardBlockWithAlteredAccounts{shardBlock: &api.Block{Shard: 0, Nonce: 40, MiniBlocks: []*api.MiniBlock{
 		{SourceShard: 0, DestinationShard: 0, Transactions: []*transaction.ApiTransactionResult{
 			{Sender: "alice", Receiver: "bob"},
 		}},
 		{SourceShard: 1, DestinationShard: 0, Transactions: []*transaction.ApiTransactionResult{
 			{Sender: "alice", Receiver: "carol"},
 		}},
-	}})
+	}}})
 
-	builder.addShardBlock(&api.Block{Shard: 1, Nonce: 41, MiniBlocks: []*api.MiniBlock{
+	builder.addShardBlock(&shardBlockWithAlteredAccounts{shardBlock: &api.Block{Shard: 1, Nonce: 41, MiniBlocks: []*api.MiniBlock{
 		{SourceShard: 0, DestinationShard: 1, Transactions: []*transaction.ApiTransactionResult{
 			{Sender: "alice", Receiver: "carol"},
 		}},
@@ -99,7 +99,7 @@ func TestHyperblockBuilderWithNotarizedAtSourceTxs(t *testing.T) {
 		{SourceShard: 1, DestinationShard: 1, Type: "PeerBlock", Transactions: []*transaction.ApiTransactionResult{
 			{Sender: "foo", Receiver: "bar"},
 		}},
-	}})
+	}}})
 
 	hyperblock := builder.build(true)
 


### PR DESCRIPTION
- Added extra query parameter `withAlteredAccounts` for hyper block proxy API.
- If used, altered accounts will be included in every notarized block by meta