### PR TITLE
Remove withMetaData

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,10 +73,8 @@ For more details, go to [docs.elrond.com](https://docs.elrond.com/sdk-and-tools/
 - `/v1.0/block/:shardID/by-hash/:hash?withTxs=true`    (GET) --> returns a block by hash, with transactions included
 - `/v1.0/block/:shardID/altered-accounts/by-nonce/:nonce`    (GET) --> returns altered accounts in the given block by nonce
 - `/v1.0/block/:shardID/altered-accounts/by-nonce/:nonce?tokens=token1,token2`    (GET) --> returns altered accounts in the given block by nonce, filtered out by given tokens
-- `/v1.0/block/:shardID/altered-accounts/by-nonce/:nonce?tokens=token1,token2&withMetadata=true`    (GET) --> returns altered accounts in the given block by nonce, filtered out by given tokens. For each esdt, it will also add its metadata
 - `/v1.0/block/:shardID/altered-accounts/by-hash/:hash`    (GET) --> returns altered accounts in the given block by hash
 - `/v1.0/block/:shardID/altered-accounts/by-hash/:hash?tokens=token1,token2`    (GET) --> returns altered accounts in the given block by hash, filtered out by given tokens
-- `/v1.0/block/:shardID/altered-accounts/by-hash/:hash?tokens=token1,token2&withMetadata=true`    (GET) --> returns altered accounts in the given block by hash, filtered out by given tokens. For each esdt, it will also add its metadata
 
 Please note that `altered-accounts` endpoints will only work if the backing observers of the Proxy have support for historical balances (`--operation-mode historical-balances` when starting the node)
 
@@ -92,9 +90,9 @@ Please note that `altered-accounts` endpoints will only work if the backing obse
 ### hyperblock
 
 - `/v1.0/hyperblock/by-nonce/:nonce`  (GET) --> returns a hyperblock by nonce, with transactions included
-- `/v1.0/hyperblock/by-nonce/:nonce?withAlteredAccounts=true`  (GET) --> returns a hyperblock by nonce, with transactions and altered accounts in each notarized block. Other available query parameters are `&tokens=token1,token2&withMetadata=true` as described in the `block` section above
+- `/v1.0/hyperblock/by-nonce/:nonce?withAlteredAccounts=true`  (GET) --> returns a hyperblock by nonce, with transactions and altered accounts in each notarized block. Other available query parameters are `&tokens=token1,token2` as described in the `block` section above
 - `/v1.0/hyperblock/by-hash/:hash`    (GET) --> returns a hyperblock by hash, with transactions included
-- `/v1.0/hyperblock/by-hash/:hash?withAlteredAccounts=true`  (GET) --> returns a hyperblock by hash, with transactions and altered accounts in each notarized block. Other available query parameters are `&tokens=token1,token2&withMetadata=true` as described in the `block` section above
+- `/v1.0/hyperblock/by-hash/:hash?withAlteredAccounts=true`  (GET) --> returns a hyperblock by hash, with transactions and altered accounts in each notarized block. Other available query parameters are `&tokens=token1,token2` as described in the `block` section above
 
 # V_next
 

--- a/api/groups/baseBlockGroup_test.go
+++ b/api/groups/baseBlockGroup_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 
 	"github.com/ElrondNetwork/elrond-go-core/data/api"
@@ -307,15 +306,6 @@ func TestGetAlteredAccountsByNonce(t *testing.T) {
 		require.Equal(t, apiErrors.ErrCannotParseNonce.Error(), apiResp.Error)
 	})
 
-	t.Run("invalid options, should return error", func(t *testing.T) {
-		t.Parallel()
-
-		apiResp := getAlteredAccounts(t, ws, "/block/0/altered-accounts/by-nonce/4?withMetadata=invalid", http.StatusBadRequest)
-		require.Equal(t, data.ReturnCodeRequestError, apiResp.Code)
-		require.Empty(t, apiResp.Data)
-		require.True(t, strings.Contains(apiResp.Error, apiErrors.ErrBadUrlParams.Error()))
-	})
-
 	t.Run("could not get response from facade, should return error", func(t *testing.T) {
 		t.Parallel()
 
@@ -371,7 +361,6 @@ func TestGetAlteredAccountsByNonce(t *testing.T) {
 				require.Equal(t, uint64(4), nonce)
 				require.Equal(t, common.GetAlteredAccountsForBlockOptions{
 					TokensFilter: "token1",
-					WithMetadata: true,
 				}, options)
 				return expectedApiResponse, nil
 			},
@@ -381,7 +370,7 @@ func TestGetAlteredAccountsByNonce(t *testing.T) {
 
 		wsValid := startProxyServer(blockGroupValid, blockPath)
 
-		apiResp := getAlteredAccounts(t, wsValid, "/block/0/altered-accounts/by-nonce/4?tokens=token1&withMetadata=True", http.StatusOK)
+		apiResp := getAlteredAccounts(t, wsValid, "/block/0/altered-accounts/by-nonce/4?tokens=token1", http.StatusOK)
 		require.Equal(t, expectedApiResponse, apiResp)
 	})
 }
@@ -411,15 +400,6 @@ func TestGetAlteredAccountsByHash(t *testing.T) {
 		require.Equal(t, data.ReturnCodeRequestError, apiResp.Code)
 		require.Empty(t, apiResp.Data)
 		require.Equal(t, apiErrors.ErrInvalidBlockHashParam.Error(), apiResp.Error)
-	})
-
-	t.Run("invalid options, should return error", func(t *testing.T) {
-		t.Parallel()
-
-		apiResp := getAlteredAccounts(t, ws, "/block/0/altered-accounts/by-hash/aaff?withMetadata=invalid", http.StatusBadRequest)
-		require.Equal(t, data.ReturnCodeRequestError, apiResp.Code)
-		require.Empty(t, apiResp.Data)
-		require.True(t, strings.Contains(apiResp.Error, apiErrors.ErrBadUrlParams.Error()))
 	})
 
 	t.Run("could not get response from facade, should return error", func(t *testing.T) {
@@ -477,7 +457,6 @@ func TestGetAlteredAccountsByHash(t *testing.T) {
 				require.Equal(t, "aaff", hash)
 				require.Equal(t, common.GetAlteredAccountsForBlockOptions{
 					TokensFilter: "token1",
-					WithMetadata: true,
 				}, options)
 				return expectedApiResponse, nil
 			},
@@ -487,7 +466,7 @@ func TestGetAlteredAccountsByHash(t *testing.T) {
 
 		wsValid := startProxyServer(blockGroupValid, blockPath)
 
-		apiResp := getAlteredAccounts(t, wsValid, "/block/0/altered-accounts/by-hash/aaff?tokens=token1&withMetadata=True", http.StatusOK)
+		apiResp := getAlteredAccounts(t, wsValid, "/block/0/altered-accounts/by-hash/aaff?tokens=token1", http.StatusOK)
 		require.Equal(t, expectedApiResponse, apiResp)
 	})
 }

--- a/api/groups/errors.go
+++ b/api/groups/errors.go
@@ -13,6 +13,3 @@ var ErrHandlerDoesNotExist = errors.New("handler does not exist")
 
 // ErrWrongTypeAssertion signals that a wrong type assertion issue was found during the execution
 var ErrWrongTypeAssertion = errors.New("wrong type assertion")
-
-// ErrIncompatibleWithMetadataParam signals a request error, because withMetadata should only be used with the tokens param
-var ErrIncompatibleWithMetadataParam = errors.New("withMetadata param should only be used with the tokens param")

--- a/api/groups/urlParams.go
+++ b/api/groups/urlParams.go
@@ -142,16 +142,8 @@ func parseTransactionsPoolQueryOptions(c *gin.Context) (common.TransactionsPoolO
 
 func parseAlteredAccountOptions(c *gin.Context) (common.GetAlteredAccountsForBlockOptions, error) {
 	tokensFilter := parseStringUrlParam(c, common.UrlParameterTokensFilter)
-	withMetaData, err := parseBoolUrlParam(c, common.UrlParameterWithMetadata)
-	if err != nil {
-		return common.GetAlteredAccountsForBlockOptions{}, err
-	}
-	if withMetaData && len(tokensFilter) == 0 {
-		return common.GetAlteredAccountsForBlockOptions{}, ErrIncompatibleWithMetadataParam
-	}
 
 	return common.GetAlteredAccountsForBlockOptions{
 		TokensFilter: tokensFilter,
-		WithMetadata: withMetaData,
 	}, nil
 }

--- a/api/groups/urlParams_test.go
+++ b/api/groups/urlParams_test.go
@@ -64,18 +64,6 @@ func TestParseHyperblockQueryOptions(t *testing.T) {
 		require.Empty(t, options)
 	})
 
-	t.Run("could not parse withAlteredAccounts params, should return error", func(t *testing.T) {
-		t.Parallel()
-
-		query := fmt.Sprintf("%s=true&%s=true",
-			common.UrlParameterWithAlteredAccounts,
-			common.UrlParameterWithMetadata,
-		)
-		options, err := parseHyperblockQueryOptions(createDummyGinContextWithQuery(query))
-		require.Equal(t, ErrIncompatibleWithMetadataParam, err)
-		require.Empty(t, options)
-	})
-
 	t.Run("with logs", func(t *testing.T) {
 		t.Parallel()
 
@@ -106,10 +94,9 @@ func TestParseHyperblockQueryOptions(t *testing.T) {
 	t.Run("with altered accounts and query params", func(t *testing.T) {
 		t.Parallel()
 
-		query := fmt.Sprintf("%s=true&%s=*&%s=true",
+		query := fmt.Sprintf("%s=true&%s=*",
 			common.UrlParameterWithAlteredAccounts,
 			common.UrlParameterTokensFilter,
-			common.UrlParameterWithMetadata,
 		)
 		options, err := parseHyperblockQueryOptions(createDummyGinContextWithQuery(query))
 		require.Nil(t, err)
@@ -117,7 +104,6 @@ func TestParseHyperblockQueryOptions(t *testing.T) {
 			WithAlteredAccounts: true,
 			AlteredAccountsOptions: common.GetAlteredAccountsForBlockOptions{
 				TokensFilter: "*",
-				WithMetadata: true,
 			},
 		}, options)
 	})
@@ -246,33 +232,11 @@ func createDummyGinContextWithQuery(rawQuery string) *gin.Context {
 func TestParseAlteredAccountOptions(t *testing.T) {
 	t.Parallel()
 
-	t.Run("invalid bool param for withMetaData, should return error", func(t *testing.T) {
-		t.Parallel()
+	c := createDummyGinContextWithQuery("tokens=token1,token2")
+	options, err := parseAlteredAccountOptions(c)
+	require.Equal(t, common.GetAlteredAccountsForBlockOptions{
+		TokensFilter: "token1,token2",
+	}, options)
+	require.Nil(t, err)
 
-		c := createDummyGinContextWithQuery("withMetadata=invalid")
-		options, err := parseAlteredAccountOptions(c)
-		require.Equal(t, common.GetAlteredAccountsForBlockOptions{}, options)
-		require.NotNil(t, err)
-	})
-
-	t.Run("withMetadata param selected without tokens, should return error", func(t *testing.T) {
-		t.Parallel()
-
-		c := createDummyGinContextWithQuery("withMetadata=True")
-		options, err := parseAlteredAccountOptions(c)
-		require.Equal(t, common.GetAlteredAccountsForBlockOptions{}, options)
-		require.Equal(t, ErrIncompatibleWithMetadataParam, err)
-	})
-
-	t.Run("should work", func(t *testing.T) {
-		t.Parallel()
-
-		c := createDummyGinContextWithQuery("withMetadata=True&tokens=token1,token2")
-		options, err := parseAlteredAccountOptions(c)
-		require.Equal(t, common.GetAlteredAccountsForBlockOptions{
-			TokensFilter: "token1,token2",
-			WithMetadata: true,
-		}, options)
-		require.Nil(t, err)
-	})
 }

--- a/common/options.go
+++ b/common/options.go
@@ -30,8 +30,6 @@ const (
 	UrlParameterLastNonce = "last-nonce"
 	// UrlParameterNonceGaps represents the name of an URL parameter
 	UrlParameterNonceGaps = "nonce-gaps"
-	// UrlParameterWithMetadata represents the name of an URL parameter
-	UrlParameterWithMetadata = "withMetadata"
 	// UrlParameterTokensFilter represents the name of an URL parameter
 	UrlParameterTokensFilter = "tokens"
 	// UrlParameterWithAlteredAccounts represents the name of an URL parameter
@@ -74,7 +72,6 @@ type TransactionsPoolOptions struct {
 // GetAlteredAccountsForBlockOptions specifies the options for returning altered accounts for a given block
 type GetAlteredAccountsForBlockOptions struct {
 	TokensFilter string
-	WithMetadata bool
 }
 
 // BuildUrlWithBlockQueryOptions builds an URL with block query parameters
@@ -122,9 +119,6 @@ func BuildUrlWithAlteredAccountsQueryOptions(path string, options GetAlteredAcco
 
 	if len(options.TokensFilter) != 0 {
 		query.Set(UrlParameterTokensFilter, options.TokensFilter)
-	}
-	if options.WithMetadata {
-		query.Set(UrlParameterWithMetadata, "true")
 	}
 
 	u.RawQuery = query.Encode()

--- a/common/queries_test.go
+++ b/common/queries_test.go
@@ -28,15 +28,7 @@ func TestBuildUrlWithAlteredAccountsQueryOptions(t *testing.T) {
 
 	url = BuildUrlWithAlteredAccountsQueryOptions("path", GetAlteredAccountsForBlockOptions{
 		TokensFilter: "token1,token2,token3",
-		WithMetadata: false,
 	})
 	// 2C is the ascii hex encoding of (,)
 	require.Equal(t, "path?tokens=token1%2Ctoken2%2Ctoken3", url)
-
-	url = BuildUrlWithAlteredAccountsQueryOptions("path", GetAlteredAccountsForBlockOptions{
-		TokensFilter: "token1,token2,token3",
-		WithMetadata: true,
-	})
-	// 2C is the ascii hex encoding of (,)
-	require.Equal(t, "path?tokens=token1%2Ctoken2%2Ctoken3&withMetadata=true", url)
 }

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/ElrondNetwork/elastic-indexer-go v1.2.30
-	github.com/ElrondNetwork/elrond-go-core v1.1.25-0.20221116135507-b8b878809ae7
+	github.com/ElrondNetwork/elrond-go-core v1.1.25
 	github.com/ElrondNetwork/elrond-go-crypto v1.0.1
 	github.com/ElrondNetwork/elrond-go-logger v1.0.9
 	github.com/elastic/go-elasticsearch/v7 v7.12.0

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/ElrondNetwork/elastic-indexer-go v1.2.30
-	github.com/ElrondNetwork/elrond-go-core v1.1.24
+	github.com/ElrondNetwork/elrond-go-core v1.1.25-0.20221116135507-b8b878809ae7
 	github.com/ElrondNetwork/elrond-go-crypto v1.0.1
 	github.com/ElrondNetwork/elrond-go-logger v1.0.9
 	github.com/elastic/go-elasticsearch/v7 v7.12.0

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/ElrondNetwork/elastic-indexer-go v1.2.30/go.mod h1:QOIz1afy53y30Sngqo
 github.com/ElrondNetwork/elrond-go-core v1.0.0/go.mod h1:FQMem7fFF4+8pQ6lVsBZq6yO+smD0nV23P4bJpmPjTo=
 github.com/ElrondNetwork/elrond-go-core v1.1.7/go.mod h1:O9FkkTT2H9kxCzfn40TbhoCDXzGmUrRVusMomhK/Y3g=
 github.com/ElrondNetwork/elrond-go-core v1.1.14/go.mod h1:Yz8JK5sGBctw7+gU8j2mZHbzQ09Ek4XHJ4Uinq1N6nM=
-github.com/ElrondNetwork/elrond-go-core v1.1.25-0.20221116135507-b8b878809ae7 h1:6ZV/4RzavGkIliQURvkdyLx0kKeCf6lJY9IfCdYsJMA=
-github.com/ElrondNetwork/elrond-go-core v1.1.25-0.20221116135507-b8b878809ae7/go.mod h1:UcZAiUqKBv3M3U6pJkYqIAx4OKubLYIc0QBVN+bY29g=
+github.com/ElrondNetwork/elrond-go-core v1.1.25 h1:jfO2TsV161bPMLbocjdNR+iy0lNKpfYwA4t5lNAFoK8=
+github.com/ElrondNetwork/elrond-go-core v1.1.25/go.mod h1:UcZAiUqKBv3M3U6pJkYqIAx4OKubLYIc0QBVN+bY29g=
 github.com/ElrondNetwork/elrond-go-crypto v1.0.1 h1:xJUUshIZQ7h+rG7Art/9QHVyaPRV1wEjrxXYBdpmRlM=
 github.com/ElrondNetwork/elrond-go-crypto v1.0.1/go.mod h1:uunsvweBrrhVojL8uiQSaTPsl3YIQ9iBqtYGM6xs4s0=
 github.com/ElrondNetwork/elrond-go-logger v1.0.4/go.mod h1:e5D+c97lKUfFdAzFX7rrI2Igl/z4Y0RkKYKWyzprTGk=

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/ElrondNetwork/elastic-indexer-go v1.2.30/go.mod h1:QOIz1afy53y30Sngqo
 github.com/ElrondNetwork/elrond-go-core v1.0.0/go.mod h1:FQMem7fFF4+8pQ6lVsBZq6yO+smD0nV23P4bJpmPjTo=
 github.com/ElrondNetwork/elrond-go-core v1.1.7/go.mod h1:O9FkkTT2H9kxCzfn40TbhoCDXzGmUrRVusMomhK/Y3g=
 github.com/ElrondNetwork/elrond-go-core v1.1.14/go.mod h1:Yz8JK5sGBctw7+gU8j2mZHbzQ09Ek4XHJ4Uinq1N6nM=
-github.com/ElrondNetwork/elrond-go-core v1.1.24 h1:jamx50C1dP50uwh11EXT0+4pq0E0G3YYTK2xKEewDEk=
-github.com/ElrondNetwork/elrond-go-core v1.1.24/go.mod h1:UcZAiUqKBv3M3U6pJkYqIAx4OKubLYIc0QBVN+bY29g=
+github.com/ElrondNetwork/elrond-go-core v1.1.25-0.20221116135507-b8b878809ae7 h1:6ZV/4RzavGkIliQURvkdyLx0kKeCf6lJY9IfCdYsJMA=
+github.com/ElrondNetwork/elrond-go-core v1.1.25-0.20221116135507-b8b878809ae7/go.mod h1:UcZAiUqKBv3M3U6pJkYqIAx4OKubLYIc0QBVN+bY29g=
 github.com/ElrondNetwork/elrond-go-crypto v1.0.1 h1:xJUUshIZQ7h+rG7Art/9QHVyaPRV1wEjrxXYBdpmRlM=
 github.com/ElrondNetwork/elrond-go-crypto v1.0.1/go.mod h1:uunsvweBrrhVojL8uiQSaTPsl3YIQ9iBqtYGM6xs4s0=
 github.com/ElrondNetwork/elrond-go-logger v1.0.4/go.mod h1:e5D+c97lKUfFdAzFX7rrI2Igl/z4Y0RkKYKWyzprTGk=


### PR DESCRIPTION
Removed `MetaData` from api responses, since it could not be consistently provided.
This information is also available from logs, at each `NFTCreate` builtin function call.

This branch successfully passed testing from @gabi-vuls 