### PR TITLE
Same order of SCRS and Events

### DIFF
--- a/process/export_test.go
+++ b/process/export_test.go
@@ -32,6 +32,11 @@ func (tp *TransactionProcessor) ComputeTransactionStatus(tx *transaction.ApiTran
 	return tp.computeTransactionStatus(tx, withResults)
 }
 
+// ApplySortOnScrs -
+func ApplySortOnScrs(tx *transaction.ApiTransactionResult) *transaction.ApiTransactionResult {
+	return applySortOnScrs(tx)
+}
+
 // CheckIfFailed -
 func CheckIfFailed(logs []*transaction.ApiLogs) (bool, string) {
 	return checkIfFailed(logs)

--- a/process/logsevents/logsMerger_test.go
+++ b/process/logsevents/logsMerger_test.go
@@ -25,6 +25,7 @@ func TestNewLogsMerger(t *testing.T) {
 	lp, err = NewLogsMerger(hasher, marshalizer)
 	require.NotNil(t, lp)
 	require.Nil(t, err)
+	require.False(t, lp.IsInterfaceNil())
 }
 
 func TestLogsMerger_MergeLogsNoLogsOnDst(t *testing.T) {
@@ -67,7 +68,7 @@ func TestLogsMerger_MergeLogsNoLogsOnSource(t *testing.T) {
 	require.Equal(t, destinationLog, res)
 }
 
-func TestLogsMerger_MergeLogs(t *testing.T) {
+func TestLogsMerger_MergeLogsAlwaysSameOrder(t *testing.T) {
 	hasher, _ := hasherFactory.NewHasher("blake2b")
 	marshalizer, _ := marshalFactory.NewMarshalizer("json")
 	lp, _ := NewLogsMerger(hasher, marshalizer)
@@ -97,4 +98,15 @@ func TestLogsMerger_MergeLogs(t *testing.T) {
 
 	res := lp.MergeLogEvents(sourceLog, destinationLog)
 	require.Len(t, res.Events, 3)
+	require.Equal(t, []*transaction.Events{
+		{
+			Data: []byte("data1"),
+		},
+		{
+			Data: []byte("data2"),
+		},
+		{
+			Data: []byte("data3"),
+		},
+	}, res.Events)
 }

--- a/process/transactionProcessor_test.go
+++ b/process/transactionProcessor_test.go
@@ -2193,3 +2193,52 @@ func TestTransactionProcessor_GetProcessedStatusIntraShardRelayedV3WithMoveBalan
 	status := tp.ComputeTransactionStatus(txWithSCRs.Transaction, true)
 	require.Equal(t, string(transaction.TxStatusSuccess), status.Status)
 }
+
+func TestApplySortTxWithScrs(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil tx should no panic", func(t *testing.T) {
+		require.NotPanics(t, func() {
+			_ = process.ApplySortOnScrs(nil)
+		})
+	})
+
+	t.Run("tx with no scrs should return same tx", func(t *testing.T) {
+		tx := &transaction.ApiTransactionResult{
+			SmartContractResults: nil,
+		}
+
+		require.Equal(t, tx, process.ApplySortOnScrs(tx))
+	})
+
+	t.Run("scrs should be sorted by hash", func(t *testing.T) {
+		tx := &transaction.ApiTransactionResult{
+			SmartContractResults: []*transaction.ApiSmartContractResult{
+				{
+					Hash: "b",
+				},
+				{
+					Hash: "c",
+				},
+				{
+					Hash: "a",
+				},
+			},
+		}
+
+		expectedScrsSlice := []*transaction.ApiSmartContractResult{
+			{
+				Hash: "a",
+			},
+			{
+				Hash: "b",
+			},
+			{
+				Hash: "c",
+			},
+		}
+
+		txAfterSort := process.ApplySortOnScrs(tx)
+		require.Equal(t, expectedScrsSlice, txAfterSort.SmartContractResults)
+	})
+}


### PR DESCRIPTION
- Refactor `/transaction/:txHash` endpoint to ensure smart contract results and events are always returned in the same order.
